### PR TITLE
Fix `reveal` action

### DIFF
--- a/autoload/fern/helper.vim
+++ b/autoload/fern/helper.vim
@@ -124,6 +124,12 @@ function! s:helper.expand_node(key) abort
   let node = fern#internal#node#find(a:key, self.fern.nodes)
   if empty(node)
     return s:Promise.reject(printf('failed to find a node %s', a:key))
+  elseif node.status is# self.STATUS_NONE
+    " To improve UX, reload owner instead
+    return self.reload_node(node.__owner.__key)
+  elseif node.status is# self.STATUS_EXPANDED
+    " To improve UX, reload instead
+    return self.reload_node(node.__key)
   endif
   let Profile = fern#profile#start("fern#helper:helper.expand_node")
   return s:Promise.resolve()
@@ -143,6 +149,12 @@ function! s:helper.collapse_node(key) abort
   let node = fern#internal#node#find(a:key, self.fern.nodes)
   if empty(node)
     return s:Promise.reject(printf('failed to find a node %s', a:key))
+  elseif node.__owner is# v:null
+    " To improve UX, root node should NOT be collapsed and reload instead.
+    return self.reload_node(node.__key)
+  elseif node.status isnot# self.STATUS_EXPANDED
+    " To improve UX, collapse a owner node instead
+    return self.collapse_node(node.__owner.__key)
   endif
   let Profile = fern#profile#start("fern#helper:helper.collapse_node")
   return s:Promise.resolve()

--- a/autoload/fern/internal/node.vim
+++ b/autoload/fern/internal/node.vim
@@ -107,23 +107,9 @@ endfunction
 
 function! fern#internal#node#expand(node, nodes, provider, comparator, token) abort
   if a:node.status is# s:STATUS_NONE
-    " To improve UX, reload owner instead
-    return fern#internal#node#reload(
-          \ a:node.__owner,
-          \ a:nodes,
-          \ a:provider,
-          \ a:comparator,
-          \ a:token,
-          \)
+    return s:Promise.reject('cannot expand leaf node')
   elseif a:node.status is# s:STATUS_EXPANDED
-    " To improve UX, reload instead
-    return fern#internal#node#reload(
-          \ a:node,
-          \ a:nodes,
-          \ a:provider,
-          \ a:comparator,
-          \ a:token,
-          \)
+    return s:Promise.resolve(a:nodes)
   elseif has_key(a:node.concealed, '__promise_expand')
     return a:node.concealed.__promise_expand
   elseif has_key(a:node, 'concealed.__promise_collapse')
@@ -146,24 +132,10 @@ function! fern#internal#node#expand(node, nodes, provider, comparator, token) ab
 endfunction
 
 function! fern#internal#node#collapse(node, nodes, provider, comparator, token) abort
-  if a:node.__owner is# v:null
-    " To improve UX, root node should NOT be collapsed and reload instead.
-    return fern#internal#node#reload(
-          \ a:node,
-          \ a:nodes,
-          \ a:provider,
-          \ a:comparator,
-          \ a:token,
-          \)
-  elseif a:node.status isnot# s:STATUS_EXPANDED
-    " To improve UX, collapse a owner node instead
-    return fern#internal#node#collapse(
-          \ a:node.__owner,
-          \ a:nodes,
-          \ a:provider,
-          \ a:comparator,
-          \ a:token,
-          \)
+  if a:node.status is# s:STATUS_NONE
+    return s:Promise.reject('cannot collapse leaf node')
+  elseif a:node.status is# s:STATUS_COLLAPSED
+    return s:Promise.resolve(a:nodes)
   elseif has_key(a:node.concealed, '__promise_expand')
     return a:node.concealed.__promise_expand
   elseif has_key(a:node, 'concealed.__promise_collapse')

--- a/test/fern/internal/node.vimspec
+++ b/test/fern/internal/node.vimspec
@@ -253,9 +253,174 @@ Describe fern#internal#node
       Assert True(Promise.is_promise(p))
     End
 
-    It resolves to a list of nodes
+    It recursively expand nodes to focus specified nodes (1 step)
       let [r, e] = Promise.wait(
             \ fern#internal#node#reveal(['deep', 'alpha', 'beta', 'gamma'], nodes, provider, Comparator, token),
+            \ { 'timeout': TIMEOUT },
+            \)
+      Assert Equals(e, v:null)
+      Assert Equals(len(r), 8)
+      Assert Equals(r[0]._uri, '/')
+      Assert Equals(r[1]._uri, '/deep')
+      Assert Equals(r[2]._uri, '/deep/alpha')
+      Assert Equals(r[3]._uri, '/deep/alpha/beta')
+      Assert Equals(r[4]._uri, '/deep/alpha/beta/gamma')
+      Assert Equals(r[5]._uri, '/heavy')
+      Assert Equals(r[6]._uri, '/shallow')
+      Assert Equals(r[7]._uri, '/leaf')
+    End
+
+    It recursively expand nodes to focus specified nodes (step by step)
+      let [r, e] = Promise.wait(
+            \ fern#internal#node#reveal(['deep'], nodes, provider, Comparator, token),
+            \ { 'timeout': TIMEOUT },
+            \)
+      Assert Equals(e, v:null)
+      Assert Equals(len(r), 6)
+      Assert Equals(r[0]._uri, '/')
+      Assert Equals(r[1]._uri, '/deep')
+      Assert Equals(r[2]._uri, '/deep/alpha')
+      Assert Equals(r[3]._uri, '/heavy')
+      Assert Equals(r[4]._uri, '/shallow')
+      Assert Equals(r[5]._uri, '/leaf')
+
+      let [r, e] = Promise.wait(
+            \ fern#internal#node#reveal(['deep', 'alpha'], nodes, provider, Comparator, token),
+            \ { 'timeout': TIMEOUT },
+            \)
+      Assert Equals(e, v:null)
+      Assert Equals(len(r), 7)
+      Assert Equals(r[0]._uri, '/')
+      Assert Equals(r[1]._uri, '/deep')
+      Assert Equals(r[2]._uri, '/deep/alpha')
+      Assert Equals(r[3]._uri, '/deep/alpha/beta')
+      Assert Equals(r[4]._uri, '/heavy')
+      Assert Equals(r[5]._uri, '/shallow')
+      Assert Equals(r[6]._uri, '/leaf')
+
+      let [r, e] = Promise.wait(
+            \ fern#internal#node#reveal(['deep', 'alpha', 'beta'], nodes, provider, Comparator, token),
+            \ { 'timeout': TIMEOUT },
+            \)
+      Assert Equals(e, v:null)
+      Assert Equals(len(r), 8)
+      Assert Equals(r[0]._uri, '/')
+      Assert Equals(r[1]._uri, '/deep')
+      Assert Equals(r[2]._uri, '/deep/alpha')
+      Assert Equals(r[3]._uri, '/deep/alpha/beta')
+      Assert Equals(r[4]._uri, '/deep/alpha/beta/gamma')
+      Assert Equals(r[5]._uri, '/heavy')
+      Assert Equals(r[6]._uri, '/shallow')
+      Assert Equals(r[7]._uri, '/leaf')
+
+      let [r, e] = Promise.wait(
+            \ fern#internal#node#reveal(['deep', 'alpha', 'beta', 'gamma'], nodes, provider, Comparator, token),
+            \ { 'timeout': TIMEOUT },
+            \)
+      Assert Equals(e, v:null)
+      Assert Equals(len(r), 8)
+      Assert Equals(r[0]._uri, '/')
+      Assert Equals(r[1]._uri, '/deep')
+      Assert Equals(r[2]._uri, '/deep/alpha')
+      Assert Equals(r[3]._uri, '/deep/alpha/beta')
+      Assert Equals(r[4]._uri, '/deep/alpha/beta/gamma')
+      Assert Equals(r[5]._uri, '/heavy')
+      Assert Equals(r[6]._uri, '/shallow')
+      Assert Equals(r[7]._uri, '/leaf')
+
+      let [r, e] = Promise.wait(
+            \ fern#internal#node#reveal(['deep', 'alpha', 'beta', 'gamma', 'UNKNOWN'], nodes, provider, Comparator, token),
+            \ { 'timeout': TIMEOUT },
+            \)
+      Assert Equals(e, v:null)
+      Assert Equals(len(r), 8)
+      Assert Equals(r[0]._uri, '/')
+      Assert Equals(r[1]._uri, '/deep')
+      Assert Equals(r[2]._uri, '/deep/alpha')
+      Assert Equals(r[3]._uri, '/deep/alpha/beta')
+      Assert Equals(r[4]._uri, '/deep/alpha/beta/gamma')
+      Assert Equals(r[5]._uri, '/heavy')
+      Assert Equals(r[6]._uri, '/shallow')
+      Assert Equals(r[7]._uri, '/leaf')
+    End
+
+    It recursively expand nodes to focus specified nodes (1 step to UNKNOWN)
+      let [r, e] = Promise.wait(
+            \ fern#internal#node#reveal(['deep', 'alpha', 'beta', 'gamma', 'UNKNOWN'], nodes, provider, Comparator, token),
+            \ { 'timeout': TIMEOUT },
+            \)
+      Assert Equals(e, v:null)
+      Assert Equals(len(r), 8)
+      Assert Equals(r[0]._uri, '/')
+      Assert Equals(r[1]._uri, '/deep')
+      Assert Equals(r[2]._uri, '/deep/alpha')
+      Assert Equals(r[3]._uri, '/deep/alpha/beta')
+      Assert Equals(r[4]._uri, '/deep/alpha/beta/gamma')
+      Assert Equals(r[5]._uri, '/heavy')
+      Assert Equals(r[6]._uri, '/shallow')
+      Assert Equals(r[7]._uri, '/leaf')
+    End
+
+    It recursively expand nodes to focus specified nodes (step by step to UNKNOWN)
+      let [r, e] = Promise.wait(
+            \ fern#internal#node#reveal(['deep'], nodes, provider, Comparator, token),
+            \ { 'timeout': TIMEOUT },
+            \)
+      Assert Equals(e, v:null)
+      Assert Equals(len(r), 6)
+      Assert Equals(r[0]._uri, '/')
+      Assert Equals(r[1]._uri, '/deep')
+      Assert Equals(r[2]._uri, '/deep/alpha')
+      Assert Equals(r[3]._uri, '/heavy')
+      Assert Equals(r[4]._uri, '/shallow')
+      Assert Equals(r[5]._uri, '/leaf')
+
+      let [r, e] = Promise.wait(
+            \ fern#internal#node#reveal(['deep', 'alpha'], nodes, provider, Comparator, token),
+            \ { 'timeout': TIMEOUT },
+            \)
+      Assert Equals(e, v:null)
+      Assert Equals(len(r), 7)
+      Assert Equals(r[0]._uri, '/')
+      Assert Equals(r[1]._uri, '/deep')
+      Assert Equals(r[2]._uri, '/deep/alpha')
+      Assert Equals(r[3]._uri, '/deep/alpha/beta')
+      Assert Equals(r[4]._uri, '/heavy')
+      Assert Equals(r[5]._uri, '/shallow')
+      Assert Equals(r[6]._uri, '/leaf')
+
+      let [r, e] = Promise.wait(
+            \ fern#internal#node#reveal(['deep', 'alpha', 'beta'], nodes, provider, Comparator, token),
+            \ { 'timeout': TIMEOUT },
+            \)
+      Assert Equals(e, v:null)
+      Assert Equals(len(r), 8)
+      Assert Equals(r[0]._uri, '/')
+      Assert Equals(r[1]._uri, '/deep')
+      Assert Equals(r[2]._uri, '/deep/alpha')
+      Assert Equals(r[3]._uri, '/deep/alpha/beta')
+      Assert Equals(r[4]._uri, '/deep/alpha/beta/gamma')
+      Assert Equals(r[5]._uri, '/heavy')
+      Assert Equals(r[6]._uri, '/shallow')
+      Assert Equals(r[7]._uri, '/leaf')
+
+      let [r, e] = Promise.wait(
+            \ fern#internal#node#reveal(['deep', 'alpha', 'beta', 'gamma'], nodes, provider, Comparator, token),
+            \ { 'timeout': TIMEOUT },
+            \)
+      Assert Equals(e, v:null)
+      Assert Equals(len(r), 8)
+      Assert Equals(r[0]._uri, '/')
+      Assert Equals(r[1]._uri, '/deep')
+      Assert Equals(r[2]._uri, '/deep/alpha')
+      Assert Equals(r[3]._uri, '/deep/alpha/beta')
+      Assert Equals(r[4]._uri, '/deep/alpha/beta/gamma')
+      Assert Equals(r[5]._uri, '/heavy')
+      Assert Equals(r[6]._uri, '/shallow')
+      Assert Equals(r[7]._uri, '/leaf')
+
+      let [r, e] = Promise.wait(
+            \ fern#internal#node#reveal(['deep', 'alpha', 'beta', 'gamma', 'UNKNOWN'], nodes, provider, Comparator, token),
             \ { 'timeout': TIMEOUT },
             \)
       Assert Equals(e, v:null)


### PR DESCRIPTION
https://vim-jp.slack.com/archives/CLKR04BEF/p1580379370295400?thread_ts=1580377078.287400&cid=CLKR04BEF

![2020-01-30 19-11-08 2020-01-30 19_12_01](https://user-images.githubusercontent.com/546312/73476332-5f0cf080-43d5-11ea-83c3-f0948fd2971c.gif)

As above, current `reveal` is not consisntent.

![Kapture 2020-01-31 at 2 58 25](https://user-images.githubusercontent.com/546312/73476458-98456080-43d5-11ea-98c3-63774af50a71.gif)
