### PR TITLE
upgrade acitons/checkout v1 -> v2

### DIFF
--- a/.github/workflows/linux_neovim.yml
+++ b/.github/workflows/linux_neovim.yml
@@ -24,7 +24,7 @@ jobs:
             neovim_version: nightly
     runs-on: ${{matrix.os}}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Download neovim
         shell: bash
         run: |

--- a/.github/workflows/linux_vim.yml
+++ b/.github/workflows/linux_vim.yml
@@ -26,7 +26,7 @@ jobs:
             glibc_version: 2.15
     runs-on: ${{matrix.os}}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Download vim
         shell: bash
         run: |

--- a/.github/workflows/mac_neovim.yml
+++ b/.github/workflows/mac_neovim.yml
@@ -24,7 +24,7 @@ jobs:
             neovim_version: nightly
     runs-on: ${{matrix.os}}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Download neovim
         shell: bash
         run: curl -L https://github.com/neovim/neovim/releases/download/${{matrix.neovim_version}}/nvim-macos.tar.gz -o ~/nvim.tar.gz

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -13,7 +13,7 @@ jobs:
     name: runner / vint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: vint
         uses: reviewdog/action-vint@v1
         with:

--- a/.github/workflows/windows_neovim.yml
+++ b/.github/workflows/windows_neovim.yml
@@ -26,7 +26,7 @@ jobs:
             neovim_arch: win64
     runs-on: ${{matrix.os}}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Download neovim
         shell: PowerShell
         run: Invoke-WebRequest -Uri https://github.com/neovim/neovim/releases/download/${{matrix.neovim_version}}/nvim-${{matrix.neovim_arch}}.zip -OutFile neovim.zip

--- a/.github/workflows/windows_vim.yml
+++ b/.github/workflows/windows_vim.yml
@@ -28,7 +28,7 @@ jobs:
             vim_ver_path: vim81
     runs-on: ${{matrix.os}}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Download vim
         shell: PowerShell
         run: Invoke-WebRequest -Uri https://github.com/vim/vim-win32-installer/releases/download/v${{matrix.vim_version}}/gvim_${{matrix.vim_version}}_${{matrix.vim_arch}}.zip -OutFile vim.zip


### PR DESCRIPTION
actions/checkout@v2にアップグレード
こちらの方が実行時間が短くなります。

https://github.com/actions/checkout#whats-new