### PR TITLE
Massive performance improvement on Windows

### DIFF
--- a/autoload/vital/_fern/Async/Later.vim
+++ b/autoload/vital/_fern/Async/Later.vim
@@ -4,49 +4,72 @@
 function! s:_SID() abort
   return matchstr(expand('<sfile>'), '<SNR>\zs\d\+\ze__SID$')
 endfunction
-execute join(['function! vital#_fern#Async#Later#import() abort', printf("return map({'call': '', '_vital_healthcheck': ''}, \"vital#_fern#function('<SNR>%s_' . v:key)\")", s:_SID()), 'endfunction'], "\n")
+execute join(['function! vital#_fern#Async#Later#import() abort', printf("return map({'set_max_workers': '', 'call': '', 'get_max_workers': '', 'set_error_handler': '', 'get_error_handler': ''}, \"vital#_fern#function('<SNR>%s_' . v:key)\")", s:_SID()), 'endfunction'], "\n")
 delfunction s:_SID
 " ___vital___
 let s:tasks = []
-let s:timer = v:null
-
-let s:DEFAULT_WAIT_INTERVAL = 30
-
-function! s:_vital_healthcheck() abort
-  if (v:version >= 800 && !has('nvim')) || has('nvim-0.2.0')
-    return
-  endif
-  return 'This module requires Vim 8.0.0000 or Neovim 0.2.0'
-endfunction
-
+let s:workers = []
+let s:max_workers = 50
+let s:error_handler = v:null
 
 function! s:call(fn, ...) abort
   call add(s:tasks, [a:fn, a:000])
-  call s:_emit()
+  if empty(s:workers)
+    call add(s:workers, timer_start(0, s:Worker, { 'repeat': -1 }))
+  endif
 endfunction
 
+function! s:get_max_workers() abort
+  return s:max_workers
+endfunction
 
-function! s:_emit() abort
-  if v:dying || s:timer isnot# v:null || empty(s:tasks)
+function! s:set_max_workers(n) abort
+  if a:n <= 0
+    throw 'vital: Async.Later: the n must be a positive integer'
+  endif
+  let s:max_workers = a:n
+endfunction
+
+function! s:get_error_handler() abort
+  return s:error_handler
+endfunction
+
+function! s:set_error_handler(handler) abort
+  let s:error_handler = a:handler
+endfunction
+
+function! s:_default_error_handler() abort
+  let ms = split(v:exception . "\n" . v:throwpoint, '\n')
+  echohl ErrorMsg
+  for m in ms
+    echomsg m
+  endfor
+  echohl None
+endfunction
+
+function! s:_worker(...) abort
+  if v:dying
     return
   endif
-  let s:timer = timer_start(0, funcref('s:_callback'))
-endfunction
-
-function! s:_callback(timer) abort
-  let s:timer = v:null
-  if v:dying || empty(s:tasks)
+  let n_workers = len(s:workers)
+  if empty(s:tasks)
+    if n_workers
+      call timer_stop(remove(s:workers, 0))
+    endif
     return
   endif
   try
     call call('call', remove(s:tasks, 0))
   catch
-    let ms = split(v:exception . "\n" . v:throwpoint, '\r\?\n')
-    echohl ErrorMsg
-    for m in ms
-      echomsg m
-    endfor
-    echohl None
+    if s:error_handler is# v:null
+      call s:_default_error_handler()
+    else
+      call s:error_handler()
+    endif
   endtry
-  call s:_emit()
+  if n_workers < s:max_workers
+    call add(s:workers, timer_start(0, s:Worker, { 'repeat': -1 }))
+  endif
 endfunction
+
+let s:Worker = funcref('s:_worker')

--- a/autoload/vital/_fern/Async/Promise.vim
+++ b/autoload/vital/_fern/Async/Promise.vim
@@ -4,7 +4,7 @@
 function! s:_SID() abort
   return matchstr(expand('<sfile>'), '<SNR>\zs\d\+\ze__SID$')
 endfunction
-execute join(['function! vital#_fern#Async#Promise#import() abort', printf("return map({'resolve': '', 'all': '', 'wait': '', '_vital_created': '', 'race': '', 'noop': '', 'is_promise': '', 'is_available': '', 'reject': '', 'new': ''}, \"vital#_fern#function('<SNR>%s_' . v:key)\")", s:_SID()), 'endfunction'], "\n")
+execute join(['function! vital#_fern#Async#Promise#import() abort', printf("return map({'resolve': '', '_vital_depends': '', 'wait': '', '_vital_created': '', 'all': '', 'noop': '', 'is_promise': '', 'race': '', 'is_available': '', 'reject': '', 'new': '', '_vital_loaded': ''}, \"vital#_fern#function('<SNR>%s_' . v:key)\")", s:_SID()), 'endfunction'], "\n")
 delfunction s:_SID
 " ___vital___
 " ECMAScript like Promise library for asynchronous operations.
@@ -27,13 +27,21 @@ function! s:_vital_created(module) abort
   lockvar a:module.TimeoutError
 endfunction
 
+function! s:_vital_loaded(V) abort
+  let s:Later = a:V.import('Async.Later')
+endfunction
+
+function! s:_vital_depends() abort
+  return ['Async.Later']
+endfunction
+
 " @vimlint(EVL103, 1, a:resolve)
 " @vimlint(EVL103, 1, a:reject)
 function! s:noop(resolve, reject) abort
 endfunction
 " @vimlint(EVL103, 0, a:resolve)
 " @vimlint(EVL103, 0, a:reject)
-let s:NOOP = function('s:noop')
+let s:NOOP = funcref('s:noop')
 
 " Internal APIs
 
@@ -51,7 +59,7 @@ function! s:_next_id() abort
   return s:id
 endfunction
 
-" ... is added to use this function as a callback of timer_start()
+" ... is added to use this function as a callback of s:Later.call()
 function! s:_invoke_callback(settled, promise, callback, result, ...) abort
   let has_callback = a:callback isnot v:null
   let success = 1
@@ -83,7 +91,7 @@ function! s:_invoke_callback(settled, promise, callback, result, ...) abort
   endif
 endfunction
 
-" ... is added to use this function as a callback of timer_start()
+" ... is added to use this function as a callback of s:Later.call()
 function! s:_publish(promise, ...) abort
   let settled = a:promise._state
   if settled == s:PENDING
@@ -129,8 +137,8 @@ function! s:_handle_thenable(promise, thenable) abort
     call s:_subscribe(
          \   a:thenable,
          \   v:null,
-         \   function('s:_resolve', [a:promise]),
-         \   function('s:_reject', [a:promise]),
+         \   funcref('s:_resolve', [a:promise]),
+         \   funcref('s:_reject', [a:promise]),
          \ )
   endif
 endfunction
@@ -151,7 +159,7 @@ function! s:_fulfill(promise, value) abort
   let a:promise._result = a:value
   let a:promise._state = s:FULFILLED
   if !empty(a:promise._children)
-    call timer_start(0, function('s:_publish', [a:promise]))
+    call s:Later.call(funcref('s:_publish', [a:promise]))
   endif
 endfunction
 
@@ -161,7 +169,7 @@ function! s:_reject(promise, ...) abort
   endif
   let a:promise._result = a:0 > 0 ? a:1 : v:null
   let a:promise._state = s:REJECTED
-  call timer_start(0, function('s:_publish', [a:promise]))
+  call s:Later.call(funcref('s:_publish', [a:promise]))
 endfunction
 
 function! s:_notify_done(wg, index, value) abort
@@ -207,8 +215,8 @@ function! s:new(resolver) abort
   try
     if a:resolver != s:NOOP
       call a:resolver(
-      \   function('s:_resolve', [promise]),
-      \   function('s:_reject', [promise]),
+      \   funcref('s:_resolve', [promise]),
+      \   funcref('s:_reject', [promise]),
       \ )
     endif
   catch
@@ -221,11 +229,11 @@ function! s:new(resolver) abort
 endfunction
 
 function! s:all(promises) abort
-  return s:new(function('s:_all', [a:promises]))
+  return s:new(funcref('s:_all', [a:promises]))
 endfunction
 
 function! s:race(promises) abort
-  return s:new(function('s:_race', [a:promises]))
+  return s:new(funcref('s:_race', [a:promises]))
 endfunction
 
 function! s:resolve(...) abort
@@ -278,21 +286,21 @@ function! s:_promise_then(...) dict abort
   let l:Res = a:0 > 0 ? a:1 : v:null
   let l:Rej = a:0 > 1 ? a:2 : v:null
   if state == s:FULFILLED
-    call timer_start(0, function('s:_invoke_callback', [state, child, Res, parent._result]))
+    call s:Later.call(funcref('s:_invoke_callback', [state, child, Res, parent._result]))
   elseif state == s:REJECTED
-    call timer_start(0, function('s:_invoke_callback', [state, child, Rej, parent._result]))
+    call s:Later.call(funcref('s:_invoke_callback', [state, child, Rej, parent._result]))
   else
     call s:_subscribe(parent, child, Res, Rej)
   endif
   return child
 endfunction
-let s:PROMISE.then = function('s:_promise_then')
+let s:PROMISE.then = funcref('s:_promise_then')
 
 " .catch() is just a syntax sugar of .then()
 function! s:_promise_catch(...) dict abort
   return self.then(v:null, a:0 > 0 ? a:1 : v:null)
 endfunction
-let s:PROMISE.catch = function('s:_promise_catch')
+let s:PROMISE.catch = funcref('s:_promise_catch')
 
 function! s:_on_finally(CB, parent, Result) abort
   call a:CB()
@@ -309,15 +317,15 @@ function! s:_promise_finally(...) dict abort
   if a:0 == 0
     let l:CB = v:null
   else
-    let l:CB = function('s:_on_finally', [a:1, parent])
+    let l:CB = funcref('s:_on_finally', [a:1, parent])
   endif
   if state != s:PENDING
-    call timer_start(0, function('s:_invoke_callback', [state, child, CB, parent._result]))
+    call s:Later.call(funcref('s:_invoke_callback', [state, child, CB, parent._result]))
   else
     call s:_subscribe(parent, child, CB, CB)
   endif
   return child
 endfunction
-let s:PROMISE.finally = function('s:_promise_finally')
+let s:PROMISE.finally = funcref('s:_promise_finally')
 
 " vim:set et ts=2 sts=2 sw=2 tw=0:

--- a/autoload/vital/fern.vital
+++ b/autoload/vital/fern.vital
@@ -1,5 +1,5 @@
 fern
-b8641ed90604ae5c36273b1e4c24866a24aa3c25
+4d1d1575d25ab1f5c02c69d0d256d15f0cb0f69f
 
 App.Spinner
 Async.CancellationTokenSource


### PR DESCRIPTION
Based on https://github.com/vim-jp/vital.vim/pull/716 so the PR must be merged to get this in.

The PR above improve performance especially on Windows.

![Kapture 2020-02-04 at 2 03 28](https://user-images.githubusercontent.com/546312/73673759-9390ed00-46f2-11ea-9223-dee5aa5760e1.gif)


```
fern#internal#viewer:init [enter] 
| fern#helper:helper.async.expand_node [enter] 
| | fern#internal#node#expand [enter] 
| | | fern#internal#node#children [enter] 
| | | | fern#scheme#file#provider:provider_get_children [enter] 
| | | | | fern#scheme#file#provider:children_vim_readdir [enter] 
| | | | | fern#scheme#file#provider:children_vim_readdir [leave] 0.002073 [0.002073]
| | | | fern#scheme#file#provider:provider_get_children [leave] 0.016929 [0.016929]
| | | fern#internal#node#children [leave] 0.019054 [0.019054]
| | | fern#internal#node#expand [children] 0.019879 [0.019879]
| | | fern#internal#node#expand [sort] 0.005746 [0.025625]
| | | fern#internal#node#expand [extend] 0.000775 [0.026400]
| | fern#internal#node#expand [leave] 0.000503 [0.026902]
| | fern#helper:helper.async.update_nodes [enter] 
| | | fern#internal#core#update_nodes [enter] 
| | | | fern#internal#core#update_nodes [hidden] 0.001357 [0.001357]
| | | | fern#internal#core#update_nodes [include] 0.000924 [0.002281]
| | | | fern#internal#core#update_nodes [exclude] 0.000939 [0.003220]
| | | | fern#internal#core#update_nodes [let] 0.000572 [0.003792]
| | | | fern#internal#core#update_marks [enter] 
| | | | | fern#internal#core#update_marks [resolve] 0.000790 [0.000790]
| | | | | fern#internal#core#update_marks [key] 0.000784 [0.001574]
| | | | | fern#internal#core#update_marks [filter] 0.003117 [0.004690]
| | | | fern#internal#core#update_marks [leave] 0.000760 [0.005450]
| | | fern#internal#core#update_nodes [leave] 0.006720 [0.010513]
| | fern#helper:helper.async.update_nodes [leave] 0.011914 [0.011914]
| fern#helper:helper.async.expand_node [leave] 0.040544 [0.040544]
| fern#internal#viewer:init [expand] 0.047601 [0.047601]
| fern#helper:helper.async.reveal_node [enter] 
| | fern#helper:helper.async.update_nodes [enter] 
| | | fern#internal#core#update_nodes [enter] 
| | | | fern#internal#core#update_nodes [hidden] 0.001386 [0.001386]
| | | | fern#internal#core#update_nodes [include] 0.000846 [0.002232]
| | | | fern#internal#core#update_nodes [exclude] 0.000850 [0.003082]
| | | | fern#internal#core#update_nodes [let] 0.000539 [0.003622]
| | | | fern#internal#core#update_marks [enter] 
| | | | | fern#internal#core#update_marks [resolve] 0.000721 [0.000721]
| | | | | fern#internal#core#update_marks [key] 0.000856 [0.001576]
| | | | | fern#internal#core#update_marks [filter] 0.000654 [0.002231]
| | | | fern#internal#core#update_marks [leave] 0.000423 [0.002653]
| | | fern#internal#core#update_nodes [leave] 0.003671 [0.007293]
| | fern#helper:helper.async.update_nodes [leave] 0.008516 [0.008516]
| fern#helper:helper.async.reveal_node [leave] 0.009768 [0.009768]
| fern#internal#viewer:init [reveal] 0.010673 [0.058273]
| fern#helper:helper.async.redraw [enter] 
| | fern#renderer#default#s:render [enter] 
| | fern#renderer#default#s:render [leave] 0.002009 [0.002009]
| fern#helper:helper.async.redraw [leave] 0.018872 [0.018872]
| fern#internal#viewer:init [redraw] 0.019904 [0.078177]
fern#internal#viewer:init [leave] 0.000628 [0.078805]
```