### PR TITLE
Remove internal APIs from public

### DIFF
--- a/autoload/fern.vim
+++ b/autoload/fern.vim
@@ -1,5 +1,13 @@
 let s:Config = vital#fern#import('Config')
 
+" Define Public constant
+let g:fern#STATUS_NONE = 0
+let g:fern#STATUS_COLLAPSED = 1
+let g:fern#STATUS_EXPANDED = 2
+lockvar g:fern#STATUS_NONE
+lockvar g:fern#STATUS_COLLAPSED
+lockvar g:fern#STATUS_EXPANDED
+
 " Define Public variables
 call s:Config.config(expand('<sfile>:p'), {
       \ 'debug': 0,

--- a/autoload/fern.vim
+++ b/autoload/fern.vim
@@ -20,7 +20,9 @@ call s:Config.config(expand('<sfile>:p'), {
       \ 'default_include': '',
       \ 'default_exclude': '',
       \ 'renderer': 'default',
+      \ 'renderers': get(g:, 'fern#internal#core#renderers', {}),
       \ 'comparator': 'default',
+      \ 'comparators': get(g:, 'fern#internal#core#comparators', {}),
       \ 'drawer_width': 30,
       \ 'drawer_keep': v:false,
       \})

--- a/autoload/fern/helper.vim
+++ b/autoload/fern/helper.vim
@@ -32,9 +32,9 @@ function! fern#helper#call(fn, ...) abort
 endfunction
 
 let s:helper = {
-      \ 'STATUS_NONE': g:fern#internal#node#STATUS_NONE,
-      \ 'STATUS_COLLAPSED': g:fern#internal#node#STATUS_COLLAPSED,
-      \ 'STATUS_EXPANDED': g:fern#internal#node#STATUS_EXPANDED,
+      \ 'STATUS_NONE': g:fern#STATUS_NONE,
+      \ 'STATUS_COLLAPSED': g:fern#STATUS_COLLAPSED,
+      \ 'STATUS_EXPANDED': g:fern#STATUS_EXPANDED,
       \}
 
 function! s:sync_method(name, ...) abort dict

--- a/autoload/fern/internal/command/fern.vim
+++ b/autoload/fern/internal/command/fern.vim
@@ -11,7 +11,7 @@ let s:options = [
       \ '-opener=',
       \]
 
-function! fern#command#fern#command(mods, fargs) abort
+function! fern#internal#command#fern#command(mods, fargs) abort
   try
     let stay = fern#internal#args#pop(a:fargs, 'stay', v:false)
     let reveal = fern#internal#args#pop(a:fargs, 'reveal', '')
@@ -100,7 +100,7 @@ function! fern#command#fern#command(mods, fargs) abort
   endtry
 endfunction
 
-function! fern#command#fern#complete(arglead, cmdline, cursorpos) abort
+function! fern#internal#command#fern#complete(arglead, cmdline, cursorpos) abort
   if a:arglead =~# '^-opener='
     return fern#internal#complete#opener(a:arglead, a:cmdline, a:cursorpos)
   elseif a:arglead =~# '^-reveal='

--- a/autoload/fern/internal/command/focus.vim
+++ b/autoload/fern/internal/command/focus.vim
@@ -1,4 +1,4 @@
-function! fern#command#focus#command(mods, fargs) abort
+function! fern#internal#command#focus#command(mods, fargs) abort
   try
     let drawer = fern#internal#args#pop(a:fargs, 'drawer', v:false)
 
@@ -26,7 +26,7 @@ function! fern#command#focus#command(mods, fargs) abort
   endtry
 endfunction
 
-function! fern#command#focus#complete(arglead, cmdline, cursorpos) abort
+function! fern#internal#command#focus#complete(arglead, cmdline, cursorpos) abort
   return fern#internal#complete#options(a:arglead, a:cmdline, a:cursorpos)
 endfunction
 

--- a/autoload/fern/internal/core.vim
+++ b/autoload/fern/internal/core.vim
@@ -4,7 +4,7 @@ let s:AsyncLambda = vital#fern#import('Async.Lambda')
 let s:Promise = vital#fern#import('Async.Promise')
 let s:CancellationTokenSource = vital#fern#import('Async.CancellationTokenSource')
 
-let s:STATUS_EXPANDED = g:fern#internal#node#STATUS_EXPANDED
+let s:STATUS_EXPANDED = g:fern#STATUS_EXPANDED
 let s:default_renderer = function('fern#renderer#default#new')
 let s:default_comparator = function('fern#comparator#default#new')
 
@@ -77,7 +77,7 @@ endfunction
 
 function! s:get_renderer(name) abort
   try
-    let Renderer = get(g:fern#internal#core#renderers, a:name, s:default_renderer)
+    let Renderer = get(g:fern#renderers, a:name, s:default_renderer)
     return Renderer()
   catch
     call fern#logger#error('fern#internal#core:get_renderer', v:exception)
@@ -88,7 +88,7 @@ endfunction
 
 function! s:get_comparator(name) abort
   try
-    let Comparator = get(g:fern#internal#core#comparators, a:name, s:default_comparator)
+    let Comparator = get(g:fern#comparators, a:name, s:default_comparator)
     return Comparator()
   catch
     call fern#logger#error('fern#internal#core:get_comparator', v:exception)
@@ -97,7 +97,5 @@ function! s:get_comparator(name) abort
   endtry
 endfunction
 
-call s:Config.config(expand('<sfile>:p'), {
-      \ 'renderers': {},
-      \ 'comparators': {},
-      \})
+let g:fern#internal#core#renderers = g:fern#renderers
+let g:fern#internal#core#comparators = g:fern#comparators

--- a/autoload/fern/internal/mapping.vim
+++ b/autoload/fern/internal/mapping.vim
@@ -1,37 +1,6 @@
-let s:Config = vital#fern#import('Config')
-let s:Promise = vital#fern#import('Async.Promise')
-
-function! fern#internal#mapping#call(fn, ...) abort
-  try
-    call inputsave()
-    call s:Promise.resolve(call('fern#helper#call', [a:fn] + a:000))
-          \.catch({ e -> fern#logger#error(e) })
-  catch
-    call fern#logger#error(v:exception)
-  finally
-    call inputrestore()
-  endtry
+function! fern#internal#mapping#call(...) abort
+  call fern#util#deprecated('fern#internal#mapping#call', 'fern#mapping#call')
+  return call('fern#mapping#call', a:000)
 endfunction
 
-function! fern#internal#mapping#init(scheme) abort
-  let disable_default_mappings = g:fern#disable_default_mappings
-  for name in g:fern#internal#mapping#mappings
-    call fern#mapping#{name}#init(disable_default_mappings)
-  endfor
-  call fern#internal#scheme#mapping_init(a:scheme, disable_default_mappings)
-endfunction
-
-call s:Config.config(expand('<sfile>:p'), {
-      \ 'mappings': [
-      \   'tree',
-      \   'node',
-      \   'open',
-      \   'mark',
-      \   'filter',
-      \   'drawer',
-      \ ],
-      \})
-
-" Deprecated
-let g:fern#internal#mapping#enabled_mapping_presets = g:fern#internal#mapping#mappings
-
+let g:fern#internal#mapping#mappings = g:fern#mapping#mappings

--- a/autoload/fern/internal/node.vim
+++ b/autoload/fern/internal/node.vim
@@ -2,9 +2,9 @@ let s:Promise = vital#fern#import('Async.Promise')
 let s:Lambda = vital#fern#import('Lambda')
 let s:AsyncLambda = vital#fern#import('Async.Lambda')
 
-let s:STATUS_NONE = 0
-let s:STATUS_COLLAPSED = 1
-let s:STATUS_EXPANDED = 2
+let s:STATUS_NONE = g:fern#STATUS_NONE
+let s:STATUS_COLLAPSED = g:fern#STATUS_COLLAPSED
+let s:STATUS_EXPANDED = g:fern#STATUS_EXPANDED
 
 function! fern#internal#node#debug(node) abort
   if a:node is# v:null
@@ -243,7 +243,3 @@ function! s:expand_recursively(index, key, nodes, provider, comparator, token) a
         \   { -> ns },
         \ )})
 endfunction
-
-let g:fern#internal#node#STATUS_NONE = s:STATUS_NONE
-let g:fern#internal#node#STATUS_COLLAPSED = s:STATUS_COLLAPSED
-let g:fern#internal#node#STATUS_EXPANDED = s:STATUS_EXPANDED

--- a/autoload/fern/internal/viewer.vim
+++ b/autoload/fern/internal/viewer.vim
@@ -61,7 +61,7 @@ function! s:init() abort
     let helper = fern#helper#new()
     let root = helper.sync.get_root_node()
 
-    call fern#internal#mapping#init(scheme)
+    call fern#mapping#init(scheme)
     call fern#internal#drawer#init()
     call fern#internal#spinner#start()
     call helper.fern.renderer.highlight()

--- a/autoload/fern/mapping.vim
+++ b/autoload/fern/mapping.vim
@@ -1,0 +1,33 @@
+let s:Config = vital#fern#import('Config')
+let s:Promise = vital#fern#import('Async.Promise')
+
+function! fern#mapping#call(fn, ...) abort
+  try
+    call inputsave()
+    call s:Promise.resolve(call('fern#helper#call', [a:fn] + a:000))
+          \.catch({ e -> fern#logger#error(e) })
+  catch
+    call fern#logger#error(v:exception)
+  finally
+    call inputrestore()
+  endtry
+endfunction
+
+function! fern#mapping#init(scheme) abort
+  let disable_default_mappings = g:fern#disable_default_mappings
+  for name in g:fern#mapping#mappings
+    call fern#mapping#{name}#init(disable_default_mappings)
+  endfor
+  call fern#internal#scheme#mapping_init(a:scheme, disable_default_mappings)
+endfunction
+
+call s:Config.config(expand('<sfile>:p'), {
+      \ 'mappings': [
+      \   'tree',
+      \   'node',
+      \   'open',
+      \   'mark',
+      \   'filter',
+      \   'drawer',
+      \ ],
+      \})

--- a/autoload/fern/mapping/drawer.vim
+++ b/autoload/fern/mapping/drawer.vim
@@ -11,7 +11,7 @@ endfunction
 
 function! s:call(name, ...) abort
   return call(
-        \ 'fern#internal#mapping#call',
+        \ 'fern#mapping#call',
         \ [funcref(printf('s:map_%s', a:name))] + a:000,
         \)
 endfunction

--- a/autoload/fern/mapping/filter.vim
+++ b/autoload/fern/mapping/filter.vim
@@ -16,7 +16,7 @@ endfunction
 
 function! s:call(name, ...) abort
   return call(
-        \ 'fern#internal#mapping#call',
+        \ 'fern#mapping#call',
         \ [funcref(printf('s:map_%s', a:name))] + a:000,
         \)
 endfunction

--- a/autoload/fern/mapping/mark.vim
+++ b/autoload/fern/mapping/mark.vim
@@ -19,7 +19,7 @@ endfunction
 
 function! s:call(name, ...) abort
   return call(
-        \ 'fern#internal#mapping#call',
+        \ 'fern#mapping#call',
         \ [funcref(printf('s:map_%s', a:name))] + a:000,
         \)
 endfunction

--- a/autoload/fern/mapping/node.vim
+++ b/autoload/fern/mapping/node.vim
@@ -25,7 +25,7 @@ endfunction
 
 function! s:call(name, ...) abort
   return call(
-        \ 'fern#internal#mapping#call',
+        \ 'fern#mapping#call',
         \ [funcref(printf('s:map_%s', a:name))] + a:000,
         \)
 endfunction

--- a/autoload/fern/mapping/open.vim
+++ b/autoload/fern/mapping/open.vim
@@ -54,7 +54,7 @@ endfunction
 
 function! s:call(name, ...) abort
   return call(
-        \ 'fern#internal#mapping#call',
+        \ 'fern#mapping#call',
         \ [funcref(printf('s:map_%s', a:name))] + a:000,
         \)
 endfunction

--- a/autoload/fern/mapping/tree.vim
+++ b/autoload/fern/mapping/tree.vim
@@ -14,7 +14,7 @@ endfunction
 
 function! s:call(name, ...) abort
   return call(
-        \ 'fern#internal#mapping#call',
+        \ 'fern#mapping#call',
         \ [funcref(printf('s:map_%s', a:name))] + a:000,
         \)
 endfunction

--- a/autoload/fern/renderer/default.vim
+++ b/autoload/fern/renderer/default.vim
@@ -2,8 +2,8 @@ let s:Config = vital#fern#import('Config')
 let s:AsyncLambda = vital#fern#import('Async.Lambda')
 
 let s:PATTERN = '^$~.*[]\'
-let s:STATUS_NONE = g:fern#internal#node#STATUS_NONE
-let s:STATUS_COLLAPSED = g:fern#internal#node#STATUS_COLLAPSED
+let s:STATUS_NONE = g:fern#STATUS_NONE
+let s:STATUS_COLLAPSED = g:fern#STATUS_COLLAPSED
 
 function! fern#renderer#default#new() abort
   return {

--- a/autoload/fern/scheme/dict/mapping.vim
+++ b/autoload/fern/scheme/dict/mapping.vim
@@ -24,7 +24,7 @@ endfunction
 
 function! s:call(name, ...) abort
   return call(
-        \ 'fern#internal#mapping#call',
+        \ 'fern#mapping#call',
         \ [funcref(printf('s:map_%s', a:name))] + a:000,
         \)
 endfunction

--- a/autoload/fern/scheme/dict/mapping/clipboard.vim
+++ b/autoload/fern/scheme/dict/mapping/clipboard.vim
@@ -21,7 +21,7 @@ endfunction
 
 function! s:call(name, ...) abort
   return call(
-        \ 'fern#internal#mapping#call',
+        \ 'fern#mapping#call',
         \ [funcref(printf('s:map_%s', a:name))] + a:000,
         \)
 endfunction

--- a/autoload/fern/scheme/dict/mapping/rename.vim
+++ b/autoload/fern/scheme/dict/mapping/rename.vim
@@ -30,7 +30,7 @@ endfunction
 
 function! s:call(name, ...) abort
   return call(
-        \ 'fern#internal#mapping#call',
+        \ 'fern#mapping#call',
         \ [funcref(printf('s:map_%s', a:name))] + a:000,
         \)
 endfunction

--- a/autoload/fern/scheme/file/mapping.vim
+++ b/autoload/fern/scheme/file/mapping.vim
@@ -27,7 +27,7 @@ endfunction
 
 function! s:call(name, ...) abort
   return call(
-        \ 'fern#internal#mapping#call',
+        \ 'fern#mapping#call',
         \ [funcref(printf('s:map_%s', a:name))] + a:000,
         \)
 endfunction

--- a/autoload/fern/scheme/file/mapping/cd.vim
+++ b/autoload/fern/scheme/file/mapping/cd.vim
@@ -8,7 +8,7 @@ endfunction
 
 function! s:call(name, ...) abort
   return call(
-        \ 'fern#internal#mapping#call',
+        \ 'fern#mapping#call',
         \ [funcref(printf('s:map_%s', a:name))] + a:000,
         \)
 endfunction

--- a/autoload/fern/scheme/file/mapping/clipboard.vim
+++ b/autoload/fern/scheme/file/mapping/clipboard.vim
@@ -22,7 +22,7 @@ endfunction
 
 function! s:call(name, ...) abort
   return call(
-        \ 'fern#internal#mapping#call',
+        \ 'fern#mapping#call',
         \ [funcref(printf('s:map_%s', a:name))] + a:000,
         \)
 endfunction

--- a/autoload/fern/scheme/file/mapping/rename.vim
+++ b/autoload/fern/scheme/file/mapping/rename.vim
@@ -30,7 +30,7 @@ endfunction
 
 function! s:call(name, ...) abort
   return call(
-        \ 'fern#internal#mapping#call',
+        \ 'fern#mapping#call',
         \ [funcref(printf('s:map_%s', a:name))] + a:000,
         \)
 endfunction

--- a/autoload/fern/scheme/file/mapping/system.vim
+++ b/autoload/fern/scheme/file/mapping/system.vim
@@ -10,7 +10,7 @@ endfunction
 
 function! s:call(name, ...) abort
   return call(
-        \ 'fern#internal#mapping#call',
+        \ 'fern#mapping#call',
         \ [funcref(printf('s:map_%s', a:name))] + a:000,
         \)
 endfunction

--- a/autoload/fern/scheme/file/mapping/terminal.vim
+++ b/autoload/fern/scheme/file/mapping/terminal.vim
@@ -33,7 +33,7 @@ endfunction
 
 function! s:call(name, ...) abort
   return call(
-        \ 'fern#internal#mapping#call',
+        \ 'fern#mapping#call',
         \ [funcref(printf('s:map_%s', a:name))] + a:000,
         \)
 endfunction

--- a/doc/fern-develop.txt
+++ b/doc/fern-develop.txt
@@ -161,12 +161,12 @@ entire tree.
 .compare({lhs}, {rhs})
 	Compare {lhs} and {rhs} nodes and return -1, 0, or 1.
 
-*g:fern#internal#core#comparators*
+*g:fern#comparators*
 	comparator and the value is a function reference which return a
 	comparator instance when called.
 	Default: {}
 
-A 3rd-party plugin MUST extend |g:fern#internal#core#comparators| in plugin
+A 3rd-party plugin MUST extend |g:fern#comparators| in plugin
 directory to register a comparator itself like:
 >
 	if exists('g:loaded_fern_comparator_foo')
@@ -174,7 +174,7 @@ directory to register a comparator itself like:
 	endif
 	let g:loaded_fern_comparator_foo = 1
 
-	call extend(g:fern#internal#core#comparators, {
+	call extend(g:fern#comparators, {
 	      \ 'foo': function('fern#comparator#foo#new'),
 	      \})
 <
@@ -217,13 +217,13 @@ nodes as a tree.
 	Define highlight on a current buffer. The function is called prior to
 	'filetype' specification and every after |ColorScheme| has fired.
 
-*g:fern#internal#core#renderers*
+*g:fern#renderers*
 	A |Dict| to define external renderers. The key is a name of renderer
 	and the value is a function reference which return a renderer instance
 	when called.
 	Default: {}
 
-A 3rd-party plugin MUST extend |g:fern#internal#core#renderers| to register a
+A 3rd-party plugin MUST extend |g:fern#renderers| to register a
 renderer itself like:
 >
 	" plugin/fern_renderer_foo.vim
@@ -232,7 +232,7 @@ renderer itself like:
 	endif
 	let g:loaded_fern_renderer_foo = 1
 
-	call extend(g:fern#internal#core#renderers, {
+	call extend(g:fern#renderers, {
 	      \ 'foo': function('fern#renderer#foo#new'),
 	      \})
 <

--- a/doc/fern-develop.txt
+++ b/doc/fern-develop.txt
@@ -106,9 +106,9 @@ A node instance is a tree item which has the following attributes:
 
 "status"	A |Number| which indicates the node status. One of the
 		followings:
-		|g:fern#internal#node#STATUS_NONE|	Leaf node
-		|g:fern#internal#node#STATUS_COLLAPSED|	Branch node (close)
-		|g:fern#internal#node#STATUS_EXPANDED|	Branch node (open)
+		|g:fern#STATUS_NONE|	Leaf node
+		|g:fern#STATUS_COLLAPSED|	Branch node (close)
+		|g:fern#STATUS_EXPANDED|	Branch node (open)
 
 "label"		A |String| used to display the node in a tree view.
 
@@ -142,9 +142,9 @@ A node instance is a tree item which has the following attributes:
 		for each scheme. Note that any complex value should be stored
 		in "concealed" instead to avoid display error.
 
-*g:fern#internal#node#STATUS_NONE*
-*g:fern#internal#node#STATUS_COLLAPSED*
-*g:fern#internal#node#STATUS_EXPANDED*
+*g:fern#STATUS_NONE*
+*g:fern#STATUS_COLLAPSED*
+*g:fern#STATUS_EXPANDED*
 	Constant |Number| which indicates a node status.
 	STATUS_NONE means that the node is leaf and does not have any status.
 	STATUS_COLLAPSED means that the node is branch and collapsed (closed).

--- a/doc/fern.txt
+++ b/doc/fern.txt
@@ -247,12 +247,12 @@ VARIABLE						*fern-variable*
 
 *g:fern#renderer*
 	A |String| name of renderer used to render tree items. Allowed value
-	is a key of |g:fern#internal#core#renderers|.
+	is a key of |g:fern#renderers|.
 	Default: "default"
 
 *g:fern#comparator*
 	A |String| name of comparator used to sort tree items. Allowed value
-	is a key of |g:fern#internal#core#comparators|.
+	is a key of |g:fern#comparators|.
 	Default: "default"
 
 *g:fern#drawer_width*

--- a/plugin/fern.vim
+++ b/plugin/fern.vim
@@ -4,14 +4,14 @@ endif
 let g:fern#loaded = 1
 
 command! -bar -nargs=*
-      \ -complete=customlist,fern#command#fern#complete
+      \ -complete=customlist,fern#internal#command#fern#complete
       \ Fern
-      \ call fern#command#fern#command(<q-mods>, [<f-args>])
+      \ call fern#internal#command#fern#command(<q-mods>, [<f-args>])
 
 command! -bar -nargs=*
-      \ -complete=customlist,fern#command#focus#complete
+      \ -complete=customlist,fern#internal#command#focus#complete
       \ FernFocus
-      \ call fern#command#focus#command(<q-mods>, [<f-args>])
+      \ call fern#internal#command#focus#command(<q-mods>, [<f-args>])
 
 function! s:BufReadCmd() abort
   call fern#internal#viewer#init()

--- a/test/fern/helper.vimspec
+++ b/test/fern/helper.vimspec
@@ -6,7 +6,7 @@ Describe fern#helper
   Before
     noautocmd %bwipeout!
     let TIMEOUT = 5000
-    let STATUS_EXPANDED = g:fern#internal#node#STATUS_EXPANDED
+    let STATUS_EXPANDED = g:fern#STATUS_EXPANDED
     let Promise = vital#fern#import('Async.Promise')
 
     noautocmd edit fern:///debug:///

--- a/test/fern/internal/core.vimspec
+++ b/test/fern/internal/core.vimspec
@@ -1,7 +1,7 @@
 Describe fern#internal#core
   Before
     let TIMEOUT = 5000
-    let STATUS_EXPANDED = g:fern#internal#node#STATUS_EXPANDED
+    let STATUS_EXPANDED = g:fern#STATUS_EXPANDED
     let Promise = vital#fern#import('Async.Promise')
     let provider = fern#scheme#debug#provider#new()
   End

--- a/test/fern/renderer/default.vimspec
+++ b/test/fern/renderer/default.vimspec
@@ -1,7 +1,7 @@
 Describe fern#renderer#default
   Before
     let TIMEOUT = 5000
-    let STATUS_EXPANDED = g:fern#internal#node#STATUS_EXPANDED
+    let STATUS_EXPANDED = g:fern#STATUS_EXPANDED
     let Promise = vital#fern#import('Async.Promise')
     let provider = fern#scheme#debug#provider#new()
   End


### PR DESCRIPTION
Remove (rename) internal APIs from public

- `g:fern#command -> g:fern#internal#command`
- `g:fern#internal#mapping -> g:fern#mapping`
- `g:fern#internal#core#renderers -> g:fern#renderers`
- `g:fern#internal#core#comparators -> g:fern#comparators`
- `g:fern#intrenal#node#STATUS_XXXXX -> g:fern#STATUS_XXXXX`