### PR TITLE
Add -wait option to wait fern buffer

### DIFF
--- a/.github/workflows/neovim.yml
+++ b/.github/workflows/neovim.yml
@@ -36,5 +36,10 @@ jobs:
       - name: Run tests
         env:
           THEMIS_VIM: ${{ steps.vim.outputs.executable }}
+          # XXX:
+          # Overwrite %TMP% to point a correct temp directory.
+          # Note that %TMP% only affects value of 'tempname()' in Windows.
+          # https://github.community/t5/GitHub-Actions/TEMP-is-broken-on-Windows/m-p/30432#M427
+          TMP: 'C:\Users\runneradmin\AppData\Local\Temp'
         run: |
           ./vim-themis/bin/themis

--- a/.github/workflows/vim.yml
+++ b/.github/workflows/vim.yml
@@ -36,5 +36,10 @@ jobs:
       - name: Run tests
         env:
           THEMIS_VIM: ${{ steps.vim.outputs.executable }}
+          # XXX:
+          # Overwrite %TMP% to point a correct temp directory.
+          # Note that %TMP% only affects value of 'tempname()' in Windows.
+          # https://github.community/t5/GitHub-Actions/TEMP-is-broken-on-Windows/m-p/30432#M427
+          TMP: 'C:\Users\runneradmin\AppData\Local\Temp'
         run: |
           ./vim-themis/bin/themis

--- a/autoload/fern/hook.vim
+++ b/autoload/fern/hook.vim
@@ -1,0 +1,46 @@
+let s:hooks = {}
+
+function! fern#hook#add(name, callback, ...) abort
+  let options = extend({
+        \ 'id': sha256(localtime()),
+        \ 'once': v:false,
+        \}, a:0 ? a:1 : {},
+        \)
+  let s:hooks[a:name] = add(get(s:hooks, a:name, []), {
+        \ 'callback': a:callback,
+        \ 'options': options,
+        \})
+endfunction
+
+function! fern#hook#remove(name, ...) abort
+  let id = a:0 ? a:1 : v:null
+  if id is# v:null
+    let s:hooks[a:name] = []
+    return
+  endif
+  let hooks = get(s:hooks, a:name, [])
+  let keeps = []
+  for hook in hooks
+    if hook.options.id !=# id
+      call add(keeps, hook)
+    endif
+  endfor
+  let s:hooks[a:name] = keeps
+endfunction
+
+function! fern#hook#emit(name, ...) abort
+  let hooks = get(s:hooks, a:name, [])
+  let keeps = []
+  for hook in hooks
+    try
+      call call(hook.callback, a:000)
+      if !hook.options.once
+        call add(keeps, hook)
+      endif
+    catch
+      call fern#logger#error(v:exception)
+      call fern#logger#debug(v:throwpoint)
+    endtry
+  endfor
+  let s:hooks[a:name] = keeps
+endfunction

--- a/autoload/fern/internal/viewer.vim
+++ b/autoload/fern/internal/viewer.vim
@@ -86,6 +86,7 @@ function! s:init() abort
           \.finally({ -> Profile('redraw') })
           \.then({ -> helper.sync.focus_node(reveal) })
           \.finally({ -> Profile() })
+          \.then({ -> fern#hook#emit('read', helper) })
   catch
     return s:Promise.reject(v:exception)
   endtry
@@ -113,6 +114,7 @@ function! s:BufReadCmd() abort
         \.then({ -> helper.sync.set_cursor(cursor[1:2]) })
         \.then({ -> helper.async.reload_node(root.__key) })
         \.then({ -> helper.async.redraw() })
+        \.then({ -> fern#hook#emit('read', helper) })
         \.catch({ e -> fern#logger#error(e) })
 endfunction
 

--- a/autoload/fern/internal/viewer.vim
+++ b/autoload/fern/internal/viewer.vim
@@ -42,12 +42,10 @@ function! s:init() abort
   let fri = fern#internal#bufname#parse(bufname)
   if empty(fri.authority)
     let fri.authority = sha256(localtime())[:7]
+    let previous = bufname
     let bufname = fern#fri#format(fri)
-    " NOTE:
-    " Do NOT use 'keepalt' in command below to remove previous
-    " buffer name from buffer list (#75)
-    execute printf('silent file %s$', fnameescape(bufname))
-    bwipeout #
+    execute printf('silent keepalt file %s$', fnameescape(bufname))
+    execute printf('bwipeout %s', fnameescape(previous))
   endif
 
   let resource_uri = fri.path

--- a/doc/fern-develop.txt
+++ b/doc/fern-develop.txt
@@ -528,6 +528,31 @@ fern#logger#error({object}...)
 =============================================================================
 UTILITY						*fern-develop-utility*
 
+						*fern#hook#add()*
+fern#hook#add({name}, {callback}[, {options}])
+	Add the {callback} to the {name} hook.
+	The {options} may contains the followings:
+
+	"id"		A |String| which is used to remove the hook.
+			Developer must specify this to remove a hook
+			later.
+	"once"		1 to remove the hook after initial call.
+			Default: 0
+>
+	call fern#hook#add('BufRead', { -> execute('echomsg "Ready"', '') })
+<
+						*fern#hook#remove()*
+fern#hook#remove({name}[, {id}])
+	Remove the {id} hook or all hooks when missing for the {name}.
+
+						*fern#hook#emit()*
+fern#hook#emit({name}[, {args}...])
+	Emit the {name} hooks with the {args}.
+>
+	call fern#hook#add('t', { -> execute('echomsg string(a:000)', '') })
+	call fern#hook#emit('t', 'Hello', 'World')
+	" -> ['Hello', 'World']
+<
 						*fern#util#sleep()*
 fern#util#sleep({ms})
 	Return a promise which will be resolved after {ms} milliseconds.

--- a/doc/fern.txt
+++ b/doc/fern.txt
@@ -268,10 +268,12 @@ VARIABLE						*fern-variable*
 COMMAND							*fern-command*
 
 							*:Fern*
-:Fern {url} [-opener={opener}] [-stay] [-reveal={reveal}]
+:Fern {url} [-opener={opener}] [-stay] [-wait] [-reveal={reveal}]
 	Open a fern buffer in split windows style with the {opener}.
 	If -stay options is specified, the focus stays on a window where the
-	command has executed.
+	command has executed. If -wait option is specified, the command wait
+	synchronously until the fern buffer become ready.
+
 							*fern-reveal*
 	If {reveal} is specified, parent nodes of the node which is identified
 	by the {reveal} are expanded and the node will be focused.

--- a/test/behavior/buffer-list.vimspec
+++ b/test/behavior/buffer-list.vimspec
@@ -1,0 +1,27 @@
+Describe buffer-list
+  After all
+    %bwipeout!
+  End
+
+  Before
+    %bwipeout!
+  End
+
+  It Fern buffer is not listed in 'ls'
+    edit hello
+    Fern .
+    let output = split(execute('ls'), '\n')
+    Assert Match(output[0], '^\s*\d\+\s\+\#\s\+"hello"\s\+line 1$')
+    Assert Equals(len(output), 1)
+  End
+
+  It Fern command keeps 'ls!' clean
+    edit hello
+    Fern .
+    let output = split(execute('ls!'), '\n')
+    Assert Match(output[0], '^\s*\d\+\s\+\#\s\+"hello"\s\+line 1$')
+    Assert Match(output[1], '^\s*\d\+u%a-\s\+"fern://.*"\s\+line 1$')
+    Assert Equals(len(output), 2)
+  End
+End
+

--- a/test/behavior/buffer-list.vimspec
+++ b/test/behavior/buffer-list.vimspec
@@ -9,7 +9,7 @@ Describe buffer-list
 
   It Fern buffer is not listed in 'ls'
     edit hello
-    Fern .
+    Fern . -wait
     let output = split(execute('ls'), '\n')
     Assert Match(output[0], '^\s*\d\+\s\+\#\s\+"hello"\s\+line 1$')
     Assert Equals(len(output), 1)
@@ -17,7 +17,7 @@ Describe buffer-list
 
   It Fern command keeps 'ls!' clean
     edit hello
-    Fern .
+    Fern . -wait
     let output = split(execute('ls!'), '\n')
     Assert Match(output[0], '^\s*\d\+\s\+\#\s\+"hello"\s\+line 1$')
     Assert Match(output[1], '^\s*\d\+u%a-\s\+"fern://.*"\s\+line 1$')

--- a/test/fern/helper.vimspec
+++ b/test/fern/helper.vimspec
@@ -178,13 +178,13 @@ Describe fern#helper
 
         It returns 1 if the fern is shown in a project drawer
           vsplit
-          Fern debug:/// -drawer
+          Fern debug:/// -drawer -wait
           let helper = fern#helper#new()
           Assert True(helper.sync.is_drawer())
         End
 
         It returns 0 if the fern is NOT shown in a project drawer
-          Fern debug:///
+          Fern debug:/// -wait
           let helper = fern#helper#new()
           Assert False(helper.sync.is_drawer())
         End
@@ -200,15 +200,15 @@ Describe fern#helper
         End
 
         It returns a scheme name of a fern buffer
-          Fern debug:///
+          Fern debug:/// -wait
           let helper = fern#helper#new()
           Assert Equals(helper.sync.get_scheme(), 'debug')
 
-          Fern dict:///
+          Fern dict:/// -wait
           let helper = fern#helper#new()
           Assert Equals(helper.sync.get_scheme(), 'dict')
 
-          Fern file:///
+          Fern file:/// -wait
           let helper = fern#helper#new()
           Assert Equals(helper.sync.get_scheme(), 'file')
         End

--- a/test/fern/hook.vimspec
+++ b/test/fern/hook.vimspec
@@ -1,0 +1,57 @@
+Describe fern#hook
+  Describe #emit()
+    It emits hooks added by #add()
+      let ns1 = []
+      let ns2 = []
+      call fern#hook#add('t', { -> extend(ns1, a:000) })
+      call fern#hook#add('t', { -> extend(ns2, a:000) })
+      call fern#hook#emit('t', 'hello', 'world')
+      Assert Equals(ns1, ['hello', 'world'])
+      Assert Equals(ns2, ['hello', 'world'])
+    End
+
+    It emits hooks added by #add() and remove 'once' hooks
+      let ns1 = []
+      let ns2 = []
+      call fern#hook#add('t', { -> extend(ns1, a:000) })
+      call fern#hook#add('t', { -> extend(ns2, a:000) }, {
+            \ 'once': 1,
+            \})
+      call fern#hook#emit('t', 'hello', 'world')
+      Assert Equals(ns1, ['hello', 'world'])
+      Assert Equals(ns2, ['hello', 'world'])
+
+      call fern#hook#emit('t', 'hello', 'world')
+      Assert Equals(ns1, ['hello', 'world', 'hello', 'world'])
+      Assert Equals(ns2, ['hello', 'world'])
+    End
+  End
+
+  Describe #remove()
+    It removes a specfied hook
+      let ns1 = []
+      let ns2 = []
+      call fern#hook#add('t', { -> extend(ns1, a:000) })
+      call fern#hook#add('t', { -> extend(ns2, a:000) }, {
+            \ 'id': 'remove this'
+            \})
+      call fern#hook#remove('t', 'remove this')
+      call fern#hook#emit('t', 'hello', 'world')
+      Assert Equals(ns1, ['hello', 'world'])
+      Assert Equals(ns2, [])
+    End
+
+    It removes all hooks if no {id} has specified
+      let ns1 = []
+      let ns2 = []
+      call fern#hook#add('t', { -> extend(ns1, a:000) })
+      call fern#hook#add('t', { -> extend(ns2, a:000) }, {
+            \ 'id': 'remove this'
+            \})
+      call fern#hook#remove('t')
+      call fern#hook#emit('t', 'hello', 'world')
+      Assert Equals(ns1, [])
+      Assert Equals(ns2, [])
+    End
+  End
+End


### PR DESCRIPTION
Fern works asynchronously but sometimes that makes things complicated. A new `-wait` option waits until the fern buffer becomes ready.

For example

```
:Fern . | echomsg line('$')
```

Above *always* reports `1` whatever the actual content while the fern buffer has not ready yet when `line('$')` has called.

To report the correct value, use `-wait` like

```
:Fern . -wait | echomsg line('$')
```

Then the continuous command will be called AFTER the fern buffer becomes ready.