### PR TITLE
Improve path

### DIFF
--- a/autoload/fern/internal/bufname.vim
+++ b/autoload/fern/internal/bufname.vim
@@ -7,13 +7,23 @@ function! fern#internal#bufname#parse(bufname) abort
   if bufname[:6] ==# 'fern://'
     return fern#fri#parse(bufname)
   endif
-  let expr = bufname =~# '^[^\w]\+://'
-        \ ? bufname
-        \ : fern#scheme#file#fri#to_fri(bufname)
+  if bufname !~# '^[^\w]\+://'
+    let bufname = fern#internal#path#absolute(
+          \ fern#internal#filepath#to_slash(bufname),
+          \ fern#internal#filepath#to_slash(getcwd()),
+          \)
+    let bufname = fern#fri#format({
+          \ 'scheme': 'file',
+          \ 'authority': '',
+          \ 'path': bufname[1:],
+          \ 'query': {},
+          \ 'fragment': '',
+          \})
+  endif
   let out = {
         \ 'scheme': 'fern',
         \ 'authority': '',
-        \ 'path': s:escape_uri(expr),
+        \ 'path': s:escape_uri(bufname),
         \ 'query': {},
         \ 'fragment': '',
         \}

--- a/autoload/fern/internal/bufname.vim
+++ b/autoload/fern/internal/bufname.vim
@@ -1,6 +1,7 @@
 let s:PATTERN = '^$~.*[]\'
 
-function! fern#internal#bufname#parse(bufname) abort
+function! fern#internal#bufname#parse(bufname, ...) abort
+  let cwd = a:0 ? a:1 : getcwd()
   let bufname = a:bufname[-1:] ==# '$'
         \ ? a:bufname[:-2]
         \ : a:bufname
@@ -10,7 +11,7 @@ function! fern#internal#bufname#parse(bufname) abort
   if bufname !~# '^[^\w]\+://'
     let bufname = fern#internal#path#absolute(
           \ fern#internal#filepath#to_slash(bufname),
-          \ fern#internal#filepath#to_slash(getcwd()),
+          \ fern#internal#filepath#to_slash(cwd),
           \)
     let bufname = fern#fri#format({
           \ 'scheme': 'file',

--- a/autoload/fern/internal/command/fern.vim
+++ b/autoload/fern/internal/command/fern.vim
@@ -1,5 +1,3 @@
-let s:Path = vital#fern#import('System.Filepath')
-
 let s:drawer_opener = 'topleft vsplit'
 let s:options = [
       \ '-drawer',

--- a/autoload/fern/internal/command/fern.vim
+++ b/autoload/fern/internal/command/fern.vim
@@ -129,12 +129,9 @@ function! s:norm_fragment(fri) abort
     return
   endif
   let frag = fern#internal#bufname#parse(a:fri.fragment)
-  let root = split(fern#fri#parse(a:fri.path).path, '/')
-  let root = fern#internal#path#simplify(root)
-  let reveal = split(fern#fri#parse(frag.path).path, '/')
-  let reveal = fern#internal#path#simplify(reveal)
-  let reveal = fern#internal#path#relative(reveal, root)
-  let a:fri.fragment = join(reveal, '/')
+  let root = fern#fri#parse(a:fri.path).path
+  let reveal = fern#fri#parse(frag.path).path
+  let a:fri.fragment = fern#internal#path#relative(reveal, root)
 endfunction
 
 function! s:wait(condition, ...) abort

--- a/autoload/fern/internal/filepath.vim
+++ b/autoload/fern/internal/filepath.vim
@@ -1,0 +1,65 @@
+let s:Config = vital#fern#import('Config')
+
+function! fern#internal#filepath#to_slash(path) abort
+  return g:fern#internal#filepath#is_windows
+        \ ? s:to_slash_windows(a:path)
+        \ : s:to_slash_unix(a:path)
+endfunction
+
+function! fern#internal#filepath#from_slash(path) abort
+  return g:fern#internal#filepath#is_windows
+        \ ? s:from_slash_windows(a:path)
+        \ : s:to_slash_unix(a:path)
+endfunction
+
+function! fern#internal#filepath#is_root(path) abort
+  return g:fern#internal#filepath#is_windows
+        \ ? a:path ==# ''
+        \ : a:path ==# '/'
+endfunction
+
+function! fern#internal#filepath#is_drive_root(path) abort
+  return g:fern#internal#filepath#is_windows
+        \ ? a:path =~# '^\w:\\$'
+        \ : a:path ==# '/'
+endfunction
+
+function! fern#internal#filepath#is_absolute(path) abort
+  return g:fern#internal#filepath#is_windows
+        \ ? s:is_absolute_windows(a:path)
+        \ : s:is_absolute_unix(a:path)
+endfunction
+
+function! s:to_slash_windows(path) abort
+  let prefix = s:is_absolute_windows(a:path) ? '/' : ''
+  let terms = filter(split(a:path, '\\'), '!empty(v:val)')
+  return prefix . join(terms, '/')
+endfunction
+
+function! s:to_slash_unix(path) abort
+  if empty(a:path)
+    return '/'
+  endif
+  let prefix = s:is_absolute_unix(a:path) ? '/' : ''
+  let terms = filter(split(a:path, '/'), '!empty(v:val)')
+  return prefix . join(terms, '/')
+endfunction
+
+function! s:from_slash_windows(path) abort
+  let terms = filter(split(a:path, '/'), '!empty(v:val)')
+  let path = join(terms, '\')
+  return path[:2] =~# '^\w:$' ? path . '\' : path
+endfunction
+
+function! s:is_absolute_windows(path) abort
+  return a:path ==# '' || a:path[:2] =~# '^\w:\\$'
+endfunction
+
+function! s:is_absolute_unix(path) abort
+  return a:path ==# '' || a:path[:0] ==# '/'
+endfunction
+
+
+call s:Config.config(expand('<sfile>:p'), {
+      \ 'is_windows': has('win32'),
+      \})

--- a/autoload/fern/internal/filepath.vim
+++ b/autoload/fern/internal/filepath.vim
@@ -30,6 +30,14 @@ function! fern#internal#filepath#is_absolute(path) abort
         \ : s:is_absolute_unix(a:path)
 endfunction
 
+function! fern#internal#filepath#join(paths) abort
+  let paths = map(
+        \ copy(a:paths),
+        \ 'fern#internal#filepath#to_slash(v:val)',
+        \)
+  return fern#internal#filepath#from_slash(join(paths, '/'))
+endfunction
+
 function! s:to_slash_windows(path) abort
   let prefix = s:is_absolute_windows(a:path) ? '/' : ''
   let terms = filter(split(a:path, '\\'), '!empty(v:val)')

--- a/autoload/fern/internal/path.vim
+++ b/autoload/fern/internal/path.vim
@@ -1,4 +1,25 @@
 function! fern#internal#path#simplify(path) abort
+  let path = split(a:path, '/', 1)
+  let prefix = a:path[:0] ==# '/' ? '/' : ''
+  return prefix . join(s:simplify(path), '/')
+endfunction
+
+function! fern#internal#path#commonpath(paths) abort
+  let paths = map(copy(a:paths), { -> split(v:val, '/', 1) })
+  if !empty(filter(copy(paths), { -> !empty(v:val[0]) }))
+    throw 'fern: {paths} in commonpath must be absolute'
+  endif
+  let path = s:commonpath(paths)
+  return empty(path) ? '' : '/' . join(path, '/')
+endfunction
+
+function! fern#internal#path#relative(path, base) abort
+  let path = split(a:path, '/', 1)
+  let base = split(a:base, '/', 1)
+  return join(s:relative(path, base), '/')
+endfunction
+
+function! s:simplify(path) abort
   let result = []
   for term in a:path
     if term ==# '..'
@@ -16,8 +37,8 @@ function! fern#internal#path#simplify(path) abort
   return result
 endfunction
 
-function! fern#internal#path#commonpath(paths) abort
-  let paths = map(copy(a:paths), { -> fern#internal#path#simplify(v:val) })
+function! s:commonpath(paths) abort
+  let paths = map(copy(a:paths), { -> s:simplify(v:val) })
   let common = []
   for index in range(min(map(copy(paths), { -> len(v:val) })))
     let term = paths[0][index]
@@ -28,9 +49,9 @@ function! fern#internal#path#commonpath(paths) abort
   return common
 endfunction
 
-function! fern#internal#path#relative(path, base) abort
-  let path = fern#internal#path#simplify(a:path)
-  let base = fern#internal#path#simplify(a:base)
+function! s:relative(path, base) abort
+  let path = s:simplify(a:path)
+  let base = s:simplify(a:base)
   for index in range(min([len(path), len(base)]))
     if path[0] !=? base[0]
       break

--- a/autoload/fern/internal/path.vim
+++ b/autoload/fern/internal/path.vim
@@ -1,22 +1,67 @@
 function! fern#internal#path#simplify(path) abort
-  let path = split(a:path, '/', 1)
-  let prefix = a:path[:0] ==# '/' ? '/' : ''
-  return prefix . join(s:simplify(path), '/')
+  let terms = s:split(a:path)
+  let path = join(s:simplify(terms), '/')
+  let prefix = a:path[:0] ==# '/' && path[:2] !=# '../' ? '/' : ''
+  return prefix . path
 endfunction
 
 function! fern#internal#path#commonpath(paths) abort
-  let paths = map(copy(a:paths), { -> split(v:val, '/', 1) })
-  if !empty(filter(copy(paths), { -> !empty(v:val[0]) }))
-    throw 'fern: {paths} in commonpath must be absolute'
+  if !empty(filter(copy(a:paths), 'v:val[:0] !=# ''/'''))
+    throw printf('fern: path in {paths} must be an absolute path: %s', a:paths)
   endif
-  let path = s:commonpath(paths)
-  return empty(path) ? '' : '/' . join(path, '/')
+  let path = s:commonpath(map(
+        \ copy(a:paths),
+        \ 's:split(v:val)'
+        \))
+  return '/' . join(path, '/')
+endfunction
+
+function! fern#internal#path#absolute(path, base) abort
+  if a:base[:0] !=# '/'
+    throw printf('fern: {base} ("%s") must be an absolute path', a:base)
+  elseif a:path[:0] ==# '/'
+    return a:path
+  endif
+  let path = s:split(a:path)
+  let base = s:split(a:base)
+  let abspath = join(s:simplify(base + path), '/')
+  if abspath[:2] ==# '../'
+    throw printf('fern: {path} (%s) beyonds {base} (%s)', a:path, a:base)
+  endif
+  return '/' . abspath
 endfunction
 
 function! fern#internal#path#relative(path, base) abort
-  let path = split(a:path, '/', 1)
-  let base = split(a:base, '/', 1)
+  if a:base[:0] !=# '/'
+    throw printf('fern: {base} ("%s") must be an absolute path', a:base)
+  elseif a:path[:0] !=# '/'
+    return a:path
+  endif
+  let path = s:split(a:path)
+  let base = s:split(a:base)
   return join(s:relative(path, base), '/')
+endfunction
+
+function! fern#internal#path#basename(path) abort
+  if empty(a:path) || a:path ==# '/'
+    return a:path
+  endif
+  let terms = s:split(a:path)
+  return terms[-1]
+endfunction
+
+function! fern#internal#path#dirname(path) abort
+  if empty(a:path) || a:path ==# '/'
+    return a:path
+  endif
+  let terms = s:split(a:path)[:-2]
+  let path = join(s:simplify(terms), '/')
+  let prefix = a:path[:0] ==# '/' && path[:2] !=# '../' ? '/' : ''
+  return prefix . path
+endfunction
+
+function! s:split(path) abort
+  return filter(split(a:path, '/'), '!empty(v:val)')
 endfunction
 
 function! s:simplify(path) abort

--- a/autoload/fern/internal/window.vim
+++ b/autoload/fern/internal/window.vim
@@ -1,5 +1,4 @@
 let s:Config = vital#fern#import('Config')
-let s:Prompt = vital#fern#import('Prompt')
 
 function! fern#internal#window#find(predicator, ...) abort
   let n = winnr('$')

--- a/autoload/fern/mapping/filter.vim
+++ b/autoload/fern/mapping/filter.vim
@@ -1,5 +1,3 @@
-let s:Prompt = vital#fern#import('Prompt')
-
 function! fern#mapping#filter#init(disable_default_mappings) abort
   nnoremap <buffer><silent> <Plug>(fern-action-hidden-set)    :<C-u>call <SID>call('hidden_set')<CR>
   nnoremap <buffer><silent> <Plug>(fern-action-hidden-unset)  :<C-u>call <SID>call('hidden_unset')<CR>

--- a/autoload/fern/mapping/node.vim
+++ b/autoload/fern/mapping/node.vim
@@ -1,5 +1,4 @@
 let s:Promise = vital#fern#import('Async.Promise')
-let s:Prompt = vital#fern#import('Prompt')
 
 function! fern#mapping#node#init(disable_default_mappings) abort
   nnoremap <buffer><silent> <Plug>(fern-action-debug)         :<C-u>call <SID>call('debug')<CR>

--- a/autoload/fern/mapping/tree.vim
+++ b/autoload/fern/mapping/tree.vim
@@ -1,5 +1,4 @@
 let s:Promise = vital#fern#import('Async.Promise')
-let s:Prompt = vital#fern#import('Prompt')
 let s:WindowCursor = vital#fern#import('Vim.Window.Cursor')
 
 function! fern#mapping#tree#init(disable_default_mappings) abort

--- a/autoload/fern/scheme/dict/provider.vim
+++ b/autoload/fern/scheme/dict/provider.vim
@@ -1,4 +1,3 @@
-let s:Prompt = vital#fern#import('Prompt')
 let s:Promise = vital#fern#import('Async.Promise')
 
 function! fern#scheme#dict#provider#new(...) abort

--- a/autoload/fern/scheme/file/complete.vim
+++ b/autoload/fern/scheme/file/complete.vim
@@ -1,41 +1,30 @@
-let s:Path = vital#fern#import('System.Filepath')
-let s:is_windows = has('win32')
-
 function! fern#scheme#file#complete#url(arglead, cmdline, cursorpos) abort
-  let fri = fern#fri#parse(a:arglead)
-  let path = s:Path.from_slash(fri.path)
-  let path = !s:is_windows ? '/' . path : path
-  return map(
-        \ getcompletion(path, 'dir'),
-        \ { _, v -> s:to_fri(v) },
-        \)
+  let path = '/' . fern#fri#parse(a:arglead).path
+  let path = fern#internal#filepath#to_slash(path)
+  let rs = getcompletion(fern#internal#filepath#from_slash(path), 'dir')
+  call map(rs, { -> fern#internal#filepath#to_slash(v:val) })
+  call map(rs, { -> s:to_fri(v:val) })
+  return rs
 endfunction
 
 function! fern#scheme#file#complete#reveal(arglead, cmdline, cursorpos) abort
-  let base = fern#fri#parse(matchstr(a:cmdline, '\<file:///\S*')).path
-  let base = s:Path.from_slash(base)
-  let base = !s:is_windows ? '/' . base : base
+  let base = '/' . fern#fri#parse(matchstr(a:cmdline, '\<file:///\S*')).path
   let path = matchstr(a:arglead, '^-reveal=\zs.*')
-  let path = s:Path.from_slash(path)
-  let n = len(base)
-  let rs = getcompletion(s:Path.join(base, path), 'dir')
-  let rs = map(rs, { -> v:val[n :] })
-  return map(rs, { -> printf('-reveal=%s', s:to_path(v:val)) })
-endfunction
-
-function! s:to_path(path) abort
-  let path = s:Path.to_slash(a:path)
-  let path = fern#fri#encode(path)
-  return join(split(path, '/'), '/')
+  let path = fern#internal#filepath#to_slash(path)
+  let path = fern#internal#path#absolute(path, base)
+  let rs = getcompletion(fern#internal#filepath#from_slash(path), 'dir')
+  call map(rs, { -> fern#internal#filepath#to_slash(v:val) })
+  call map(rs, { -> fern#internal#path#relative(v:val, base) })
+  call map(rs, { -> printf('-reveal=%s', v:val) })
+  return rs
 endfunction
 
 function! s:to_fri(path) abort
-  let fri = {
+  return fern#fri#format({
         \ 'scheme': 'file',
         \ 'authority': '',
-        \ 'path': s:to_path(a:path),
+        \ 'path': a:path,
         \ 'query': {},
         \ 'fragment': '',
-        \}
-  return fern#fri#format(fri)
+        \})
 endfunction

--- a/autoload/fern/scheme/file/fri.vim
+++ b/autoload/fern/scheme/file/fri.vim
@@ -1,21 +1,19 @@
-let s:Path = vital#fern#import('System.Filepath')
-let s:is_windows = has('win32')
-
 function! fern#scheme#file#fri#to_fri(path) abort
-  let path = s:Path.abspath(a:path)
-  let path = s:Path.to_slash(path)
-  let path = join(split(path, '/'), '/')
-  let path = printf('file:///%s', path)
-  return path
+  call fern#util#deprecated(
+        \ 'fern#scheme#file#fri#to_fri()',
+        \ 'fern#internal#filepath module',
+        \)
+  let path = fern#internal#path#absolute(
+        \ fern#internal#filepath#to_slash(a:path),
+        \ fern#internal#filepath#to_slash(getcwd()),
+        \)
+  return printf('file://%s', path)
 endfunction
 
 function! fern#scheme#file#fri#from_fri(fri) abort
-  let path = s:is_windows ? a:fri.path : '/' . a:fri.path
-  let path = s:Path.from_slash(path)
-  if s:is_windows && path =~# '^\w:$'
-    let path .= '\'
-  endif
-  let path = s:Path.abspath(path)
-  let path = empty(path) ? '/' : path
-  return path
+  call fern#util#deprecated(
+        \ 'fern#scheme#file#fri#from_fri()',
+        \ 'fern#internal#filepath#from_slash()',
+        \)
+  return fern#internal#filepath#from_slash('/' . a:fri.path)
 endfunction

--- a/autoload/fern/scheme/file/mapping.vim
+++ b/autoload/fern/scheme/file/mapping.vim
@@ -1,6 +1,5 @@
 let s:Promise = vital#fern#import('Async.Promise')
 let s:Prompt = vital#fern#import('Prompt')
-let s:Path = vital#fern#import('System.Filepath')
 
 function! fern#scheme#file#mapping#init(disable_default_mappings) abort
   call fern#scheme#file#mapping#cd#init(a:disable_default_mappings)
@@ -62,7 +61,9 @@ function! s:map_new_file(helper) abort
   endif
   let node = a:helper.sync.get_cursor_node()
   let node = node.status isnot# a:helper.STATUS_EXPANDED ? node.__owner : node
-  let path = s:Path.join(node._path, name)
+  let path = fern#internal#filepath#to_slash(node._path)
+  let path = join([path, name], '/')
+  let path = fern#internal#filepath#from_slash(path)
   let key = node.__key + [name]
   let token = a:helper.fern.source.token
   let previous = a:helper.sync.get_cursor_node()
@@ -80,7 +81,9 @@ function! s:map_new_dir(helper) abort
   endif
   let node = a:helper.sync.get_cursor_node()
   let node = node.status isnot# a:helper.STATUS_EXPANDED ? node.__owner : node
-  let path = s:Path.join(node._path, name)
+  let path = fern#internal#filepath#to_slash(node._path)
+  let path = join([path, name], '/')
+  let path = fern#internal#filepath#from_slash(path)
   let key = node.__key + [name]
   let token = a:helper.fern.source.token
   let previous = a:helper.sync.get_cursor_node()

--- a/autoload/fern/scheme/file/mapping/clipboard.vim
+++ b/autoload/fern/scheme/file/mapping/clipboard.vim
@@ -1,6 +1,5 @@
 let s:Promise = vital#fern#import('Async.Promise')
 let s:Prompt = vital#fern#import('Prompt')
-let s:Path = vital#fern#import('System.Filepath')
 
 let s:clipboard = {
       \ 'mode': 'copy',
@@ -73,10 +72,13 @@ function! s:map_clipboard_paste(helper) abort
 
   let node = a:helper.sync.get_cursor_node()
   let node = node.status isnot# a:helper.STATUS_EXPANDED ? node.__owner : node
+  let base = fern#internal#filepath#to_slash(node._path)
   let token = a:helper.fern.source.token
   let ps = []
   for src in s:clipboard.candidates
-    let dst = s:Path.join(node._path, fnamemodify(src, ':t'))
+    let name = fern#internal#filepath#to_slash(src)
+    let name = fern#internal#path#basename(name)
+    let dst = fern#internal#filepath#from_slash(join([base, name], '/'))
     if s:clipboard.mode ==# 'move'
       echo printf('Move %s -> %s', src, dst)
       call add(ps, fern#scheme#file#shutil#move(src, dst, token))

--- a/autoload/fern/scheme/file/provider.vim
+++ b/autoload/fern/scheme/file/provider.vim
@@ -17,7 +17,7 @@ endfunction
 
 function! s:provider_get_root(uri) abort
   let fri = fern#fri#parse(a:uri)
-  let path = fern#scheme#file#fri#from_fri(fri)
+  let path = fern#internal#filepath#from_slash('/' . fri.path)
   return s:node(path)
 endfunction
 

--- a/autoload/fern/scheme/file/provider.vim
+++ b/autoload/fern/scheme/file/provider.vim
@@ -70,11 +70,14 @@ function! s:node(path) abort
   let status = isdirectory(a:path)
   let path = fern#internal#filepath#to_slash(a:path)
   let name = fern#internal#path#basename(path)
+  let bufname = status
+        \ ? printf('fern:///file://%s', path)
+        \ : a:path
   return {
         \ 'name': name,
         \ 'status': status,
         \ 'hidden': name[:0] ==# '.',
-        \ 'bufname': a:path,
+        \ 'bufname': bufname,
         \ '_path': a:path,
         \}
 endfunction

--- a/autoload/fern/scheme/file/util.vim
+++ b/autoload/fern/scheme/file/util.vim
@@ -50,3 +50,14 @@ function! fern#scheme#file#util#list_entries_glob(path, ...) abort
         \.then(s:AsyncLambda.reduce_f({ a, v -> a + v }, []))
         \.finally({ -> Profile() })
 endfunction
+
+if s:is_windows
+  function! fern#scheme#file#util#list_drives(token) abort
+    let Profile = fern#profile#start('fern#scheme#file#util#list_drives')
+    return s:Process.start(['wmic', 'logicaldisk', 'get', 'name'], { 'token': a:token })
+          \.then({ v -> v.stdout })
+          \.then(s:AsyncLambda.filter_f({ v -> v =~# '^\w:' }))
+          \.then(s:AsyncLambda.map_f({ v -> v:val[:1] . '\' }))
+          \.finally({ -> Profile() })
+  endfunction
+endif

--- a/autoload/fern/scheme/file/util.vim
+++ b/autoload/fern/scheme/file/util.vim
@@ -1,0 +1,52 @@
+let s:Promise = vital#fern#import('Async.Promise')
+let s:Process = vital#fern#import('Async.Promise.Process')
+let s:AsyncLambda = vital#fern#import('Async.Lambda')
+let s:is_windows = has('win32')
+
+if !s:is_windows && executable('ls')
+  " NOTE:
+  " The -U option means different between Linux and FreeBSD.
+  " Linux   - do not sort; list entries in directory order
+  " FreeBSD - Use time when file was created for sorting or printing.
+  " But it improve performance in Linux and just noise in FreeBSD so
+  " the option is applied.
+  function! fern#scheme#file#util#list_entries_ls(path, token) abort
+    let Profile = fern#profile#start('fern#scheme#file#util#list_entries_ls')
+    return s:Process.start(['ls', '-1AU', a:path], { 'token': a:token })
+          \.then({ v -> v.stdout })
+          \.then(s:AsyncLambda.filter_f({ v -> !empty(v) }))
+          \.then(s:AsyncLambda.map_f({ v -> a:path . '/' . v }))
+          \.finally({ -> Profile() })
+  endfunction
+endif
+
+if !s:is_windows && executable('find')
+  function! fern#scheme#file#util#list_entries_find(path, token) abort
+    let Profile = fern#profile#start('fern#scheme#file#util#list_entries_find')
+    return s:Process.start(['find', a:path, '-follow', '-maxdepth', '1'], { 'token': a:token })
+          \.then({ v -> v.stdout })
+          \.then(s:AsyncLambda.filter_f({ v -> !empty(v) && v !=# a:path }))
+          \.finally({ -> Profile() })
+  endfunction
+endif
+
+if exists('*readdir')
+  function! fern#scheme#file#util#list_entries_readdir(path, ...) abort
+    let Profile = fern#profile#start('fern#scheme#file#util#list_entries_readdir')
+    let s = s:is_windows ? '\' : '/'
+    return s:Promise.resolve(readdir(a:path))
+          \.then(s:AsyncLambda.map_f({ v -> a:path . s . v }))
+          \.finally({ -> Profile() })
+  endfunction
+endif
+
+function! fern#scheme#file#util#list_entries_glob(path, ...) abort
+  let Profile = fern#profile#start('fern#scheme#file#util#list_entries_glob')
+  let s = s:is_windows ? '\' : '/'
+  let a = s:Promise.resolve(glob(a:path . s . '*', 1, 1, 1))
+  let b = s:Promise.resolve(glob(a:path . s . '.*', 1, 1, 1))
+        \.then(s:AsyncLambda.filter_f({ v -> v[-2:] !=# s . '.' && v[-3:] !=# s . '..' }))
+  return s:Promise.all([a, b])
+        \.then(s:AsyncLambda.reduce_f({ a, v -> a + v }, []))
+        \.finally({ -> Profile() })
+endfunction

--- a/autoload/vital/_fern/Async/CancellationToken.vim
+++ b/autoload/vital/_fern/Async/CancellationToken.vim
@@ -4,7 +4,7 @@
 function! s:_SID() abort
   return matchstr(expand('<sfile>'), '<SNR>\zs\d\+\ze__SID$')
 endfunction
-execute join(['function! vital#_fern#Async#CancellationToken#import() abort', printf("return map({'_vital_created': '', '_vital_healthcheck': '', 'new': ''}, \"vital#_fern#function('<SNR>%s_' . v:key)\")", s:_SID()), 'endfunction'], "\n")
+execute join(['function! vital#_fern#Async#CancellationToken#import() abort', printf("return map({'_vital_created': '', 'new': ''}, \"vital#_fern#function('<SNR>%s_' . v:key)\")", s:_SID()), 'endfunction'], "\n")
 delfunction s:_SID
 " ___vital___
 let s:STATE_OPEN = 0
@@ -33,14 +33,6 @@ function! s:_vital_created(module) abort
   let a:module.CancelledError = s:CANCELLED_ERROR
   lockvar 3 a:module
 endfunction
-
-function! s:_vital_healthcheck() abort
-  if (v:version >= 800 && !has('nvim')) || has('nvim-0.2.0')
-    return
-  endif
-  return 'This module requires Vim 8.0.0000 or Neovim 0.2.0'
-endfunction
-
 
 function! s:new(source) abort
   let token = {

--- a/autoload/vital/_fern/Async/CancellationTokenSource.vim
+++ b/autoload/vital/_fern/Async/CancellationTokenSource.vim
@@ -4,7 +4,7 @@
 function! s:_SID() abort
   return matchstr(expand('<sfile>'), '<SNR>\zs\d\+\ze__SID$')
 endfunction
-execute join(['function! vital#_fern#Async#CancellationTokenSource#import() abort', printf("return map({'_vital_depends': '', '_vital_healthcheck': '', 'new': '', '_vital_loaded': ''}, \"vital#_fern#function('<SNR>%s_' . v:key)\")", s:_SID()), 'endfunction'], "\n")
+execute join(['function! vital#_fern#Async#CancellationTokenSource#import() abort', printf("return map({'_vital_depends': '', 'new': '', '_vital_loaded': ''}, \"vital#_fern#function('<SNR>%s_' . v:key)\")", s:_SID()), 'endfunction'], "\n")
 delfunction s:_SID
 " ___vital___
 function! s:_vital_depends() abort
@@ -14,14 +14,6 @@ endfunction
 function! s:_vital_loaded(V) abort
   let s:CancellationToken = a:V.import('Async.CancellationToken')
 endfunction
-
-function! s:_vital_healthcheck() abort
-  if (v:version >= 800 && !has('nvim')) || has('nvim-0.2.0')
-    return
-  endif
-  return 'This module requires Vim 8.0.0000 or Neovim 0.2.0'
-endfunction
-
 
 function! s:new(...) abort
   let source = {

--- a/autoload/vital/_fern/Config.vim
+++ b/autoload/vital/_fern/Config.vim
@@ -4,7 +4,7 @@
 function! s:_SID() abort
   return matchstr(expand('<sfile>'), '<SNR>\zs\d\+\ze__SID$')
 endfunction
-execute join(['function! vital#_fern#Config#import() abort', printf("return map({'define': '', 'translate': '', '_vital_healthcheck': '', 'config': ''}, \"vital#_fern#function('<SNR>%s_' . v:key)\")", s:_SID()), 'endfunction'], "\n")
+execute join(['function! vital#_fern#Config#import() abort', printf("return map({'define': '', 'translate': '', 'config': ''}, \"vital#_fern#function('<SNR>%s_' . v:key)\")", s:_SID()), 'endfunction'], "\n")
 delfunction s:_SID
 " ___vital___
 let s:plugin_name = expand('<sfile>:p:h:t')
@@ -13,13 +13,6 @@ let s:plugin_name = s:plugin_name =~# '^__.\+__$'
       \ : s:plugin_name =~# '^_.\+$'
       \   ? s:plugin_name[1:]
       \   : s:plugin_name
-
-function! s:_vital_healthcheck() abort
-  if (!has('nvim') && v:version >= 800) || has('nvim-0.2.0')
-    return
-  endif
-  return 'This module requires Vim 8.0.0000 or Neovim 0.2.0'
-endfunction
 
 function! s:define(prefix, default) abort
   let prefix = a:prefix =~# '^g:' ? a:prefix : 'g:' . a:prefix

--- a/autoload/vital/_fern/Data/List/Chunker.vim
+++ b/autoload/vital/_fern/Data/List/Chunker.vim
@@ -4,16 +4,9 @@
 function! s:_SID() abort
   return matchstr(expand('<sfile>'), '<SNR>\zs\d\+\ze__SID$')
 endfunction
-execute join(['function! vital#_fern#Data#List#Chunker#import() abort', printf("return map({'_vital_healthcheck': '', 'new': ''}, \"vital#_fern#function('<SNR>%s_' . v:key)\")", s:_SID()), 'endfunction'], "\n")
+execute join(['function! vital#_fern#Data#List#Chunker#import() abort', printf("return map({'new': ''}, \"vital#_fern#function('<SNR>%s_' . v:key)\")", s:_SID()), 'endfunction'], "\n")
 delfunction s:_SID
 " ___vital___
-function! s:_vital_healthcheck() abort
-  if (!has('nvim') && v:version >= 800) || has('nvim-0.2.0')
-    return
-  endif
-  return 'Data.List.Chunker requires Vim 8.0.0000 or Neovim 0.2.0'
-endfunction
-
 function! s:new(size, candidates) abort
   return {
         \ '__cursor': 0,

--- a/autoload/vital/_fern/System/Job.vim
+++ b/autoload/vital/_fern/System/Job.vim
@@ -4,7 +4,7 @@
 function! s:_SID() abort
   return matchstr(expand('<sfile>'), '<SNR>\zs\d\+\ze__SID$')
 endfunction
-execute join(['function! vital#_fern#System#Job#import() abort', printf("return map({'_vital_depends': '', '_vital_healthcheck': '', 'is_available': '', 'start': '', '_vital_loaded': ''}, \"vital#_fern#function('<SNR>%s_' . v:key)\")", s:_SID()), 'endfunction'], "\n")
+execute join(['function! vital#_fern#System#Job#import() abort', printf("return map({'_vital_depends': '', 'is_available': '', 'start': '', '_vital_loaded': ''}, \"vital#_fern#function('<SNR>%s_' . v:key)\")", s:_SID()), 'endfunction'], "\n")
 delfunction s:_SID
 " ___vital___
 let s:t_string = type('')
@@ -24,14 +24,6 @@ function! s:_vital_depends() abort
         \ 'System.Job.Neovim',
         \]
 endfunction
-
-function! s:_vital_healthcheck() abort
-  if has('patch-8.0.0027') || has('nvim-0.2.0')
-    return
-  endif
-  return 'This module requires Vim 8.0.0027 or Neovim 0.2.0'
-endfunction
-
 
 " Note:
 " Vim does not raise E902 on Unix system even the prog is not found so use a

--- a/test/behavior/alternate-file.vimspec
+++ b/test/behavior/alternate-file.vimspec
@@ -1,13 +1,12 @@
 Describe alternate-file
   Before all
-    let Path = vital#fern#import('System.Filepath')
     let fern_keepalt_on_edit = g:fern#keepalt_on_edit
     let workdir = tempname()
     lockvar workdir
     call mkdir(workdir, 'p')
-    call writefile([], Path.join(workdir, 'alpha'))
-    call writefile([], Path.join(workdir, 'beta'))
-    call writefile([], Path.join(workdir, 'gamma'))
+    call writefile([], fern#internal#filepath#join([workdir, 'alpha']))
+    call writefile([], fern#internal#filepath#join([workdir, 'beta']))
+    call writefile([], fern#internal#filepath#join([workdir, 'gamma']))
   End
 
   After all

--- a/test/behavior/jumplist.vimspec
+++ b/test/behavior/jumplist.vimspec
@@ -1,13 +1,12 @@
 Describe jumplist
   Before all
-    let Path = vital#fern#import('System.Filepath')
     let fern_keepjumps_on_edit = g:fern#keepjumps_on_edit
     let workdir = tempname()
     lockvar workdir
     call mkdir(workdir, 'p')
-    call writefile([], Path.join(workdir, 'alpha'))
-    call writefile([], Path.join(workdir, 'beta'))
-    call writefile([], Path.join(workdir, 'gamma'))
+    call writefile([], fern#internal#filepath#join([workdir, 'alpha']))
+    call writefile([], fern#internal#filepath#join([workdir, 'beta']))
+    call writefile([], fern#internal#filepath#join([workdir, 'gamma']))
   End
 
   After all

--- a/test/fern/internal/bufname.vimspec
+++ b/test/fern/internal/bufname.vimspec
@@ -1,4 +1,12 @@
 Describe fern#internal#bufname
+  Before all
+    let fern_internal_filepath_is_windows = g:fern#internal#filepath#is_windows
+  End
+
+  After all
+    let g:fern#internal#filepath#is_windows = fern_internal_filepath_is_windows
+  End
+
   Describe #parse()
     Context FRI bufname
       It returns FRI of fern://... from fern:///file:///foo/bar
@@ -180,9 +188,7 @@ Describe fern#internal#bufname
 
     Context FILE bufname (Unix)
       Before
-        if has('win32')
-          Skip This test must be run under Unix
-        endif
+        let g:fern#internal#filepath#is_windows = 0
       End
 
       It returns FRI of fern://... from /
@@ -214,7 +220,7 @@ Describe fern#internal#bufname
         let want = {
               \ 'scheme': 'fern',
               \ 'authority': '',
-              \ 'path': 'file:///foo/bar%3Fa&b=c',
+              \ 'path': 'file:///foo/bar%3Fa&b%3Dc',
               \ 'query': {},
               \ 'fragment': '',
               \}
@@ -226,7 +232,7 @@ Describe fern#internal#bufname
         let want = {
               \ 'scheme': 'fern',
               \ 'authority': '',
-              \ 'path': 'file:///foo/bar%3Ba&b=c',
+              \ 'path': 'file:///foo/bar%3Ba&b%3Dc',
               \ 'query': {},
               \ 'fragment': '',
               \}
@@ -250,7 +256,7 @@ Describe fern#internal#bufname
         let want = {
               \ 'scheme': 'fern',
               \ 'authority': '',
-              \ 'path': 'file:///foo/bar%3Fa&b=c%23foo/bar/hoge',
+              \ 'path': 'file:///foo/bar%3Fa&b%3Dc%23foo/bar/hoge',
               \ 'query': {},
               \ 'fragment': '',
               \}
@@ -262,7 +268,7 @@ Describe fern#internal#bufname
         let want = {
               \ 'scheme': 'fern',
               \ 'authority': '',
-              \ 'path': 'file:///foo/bar%3Ba&b=c%23foo/bar/hoge',
+              \ 'path': 'file:///foo/bar%3Ba&b%3Dc%23foo/bar/hoge',
               \ 'query': {},
               \ 'fragment': '',
               \}
@@ -272,9 +278,7 @@ Describe fern#internal#bufname
 
     Context FILE bufname (Windows)
       Before
-        if !has('win32')
-          Skip This test must be run under Windows
-        endif
+        let g:fern#internal#filepath#is_windows = 1
       End
 
       It returns FRI of fern://... from C:\
@@ -306,7 +310,7 @@ Describe fern#internal#bufname
         let want = {
               \ 'scheme': 'fern',
               \ 'authority': '',
-              \ 'path': 'file:///C:/foo/bar%3Fa&b=c',
+              \ 'path': 'file:///C:/foo/bar%3Fa&b%3Dc',
               \ 'query': {},
               \ 'fragment': '',
               \}
@@ -318,7 +322,7 @@ Describe fern#internal#bufname
         let want = {
               \ 'scheme': 'fern',
               \ 'authority': '',
-              \ 'path': 'file:///C:/foo/bar%3Ba&b=c',
+              \ 'path': 'file:///C:/foo/bar%3Ba&b%3Dc',
               \ 'query': {},
               \ 'fragment': '',
               \}
@@ -342,7 +346,7 @@ Describe fern#internal#bufname
         let want = {
               \ 'scheme': 'fern',
               \ 'authority': '',
-              \ 'path': 'file:///C:/foo/bar%3Fa&b=c%23foo/bar/hoge',
+              \ 'path': 'file:///C:/foo/bar%3Fa&b%3Dc%23foo/bar/hoge',
               \ 'query': {},
               \ 'fragment': '',
               \}
@@ -354,7 +358,7 @@ Describe fern#internal#bufname
         let want = {
               \ 'scheme': 'fern',
               \ 'authority': '',
-              \ 'path': 'file:///C:/foo/bar%3Ba&b=c%23foo/bar/hoge',
+              \ 'path': 'file:///C:/foo/bar%3Ba&b%3Dc%23foo/bar/hoge',
               \ 'query': {},
               \ 'fragment': '',
               \}

--- a/test/fern/internal/bufname.vimspec
+++ b/test/fern/internal/bufname.vimspec
@@ -189,6 +189,7 @@ Describe fern#internal#bufname
     Context FILE bufname (Unix)
       Before
         let g:fern#internal#filepath#is_windows = 0
+        let cwd = '/home/fern'
       End
 
       It returns FRI of fern://... from /
@@ -200,7 +201,7 @@ Describe fern#internal#bufname
               \ 'query': {},
               \ 'fragment': '',
               \}
-        Assert Equals(fern#internal#bufname#parse(expr), want)
+        Assert Equals(fern#internal#bufname#parse(expr, cwd), want)
       End
 
       It returns FRI of fern://... from /foo/bar
@@ -212,7 +213,7 @@ Describe fern#internal#bufname
               \ 'query': {},
               \ 'fragment': '',
               \}
-        Assert Equals(fern#internal#bufname#parse(expr), want)
+        Assert Equals(fern#internal#bufname#parse(expr, cwd), want)
       End
 
       It returns FRI of fern://... from /foo/bar?a&b=c
@@ -224,7 +225,7 @@ Describe fern#internal#bufname
               \ 'query': {},
               \ 'fragment': '',
               \}
-        Assert Equals(fern#internal#bufname#parse(expr), want)
+        Assert Equals(fern#internal#bufname#parse(expr, cwd), want)
       End
 
       It returns FRI of fern://... from /foo/bar;a&b=c
@@ -236,7 +237,7 @@ Describe fern#internal#bufname
               \ 'query': {},
               \ 'fragment': '',
               \}
-        Assert Equals(fern#internal#bufname#parse(expr), want)
+        Assert Equals(fern#internal#bufname#parse(expr, cwd), want)
       End
 
       It returns FRI of fern://... from /foo/bar#foo/bar/hoge
@@ -248,7 +249,7 @@ Describe fern#internal#bufname
               \ 'query': {},
               \ 'fragment': '',
               \}
-        Assert Equals(fern#internal#bufname#parse(expr), want)
+        Assert Equals(fern#internal#bufname#parse(expr, cwd), want)
       End
 
       It returns FRI of fern://... from /foo/bar?a&b=c#foo/bar/hoge
@@ -260,7 +261,7 @@ Describe fern#internal#bufname
               \ 'query': {},
               \ 'fragment': '',
               \}
-        Assert Equals(fern#internal#bufname#parse(expr), want)
+        Assert Equals(fern#internal#bufname#parse(expr, cwd), want)
       End
 
       It returns FRI of fern://... from /foo/bar;a&b=c#foo/bar/hoge
@@ -272,13 +273,14 @@ Describe fern#internal#bufname
               \ 'query': {},
               \ 'fragment': '',
               \}
-        Assert Equals(fern#internal#bufname#parse(expr), want)
+        Assert Equals(fern#internal#bufname#parse(expr, cwd), want)
       End
     End
 
     Context FILE bufname (Windows)
       Before
         let g:fern#internal#filepath#is_windows = 1
+        let cwd = 'C:\Users\fern'
       End
 
       It returns FRI of fern://... from C:\
@@ -290,7 +292,7 @@ Describe fern#internal#bufname
               \ 'query': {},
               \ 'fragment': '',
               \}
-        Assert Equals(fern#internal#bufname#parse(expr), want)
+        Assert Equals(fern#internal#bufname#parse(expr, cwd), want)
       End
 
       It returns FRI of fern://... from C:\foo\bar
@@ -302,7 +304,7 @@ Describe fern#internal#bufname
               \ 'query': {},
               \ 'fragment': '',
               \}
-        Assert Equals(fern#internal#bufname#parse(expr), want)
+        Assert Equals(fern#internal#bufname#parse(expr, cwd), want)
       End
 
       It returns FRI of fern://... from C:\foo\bar?a&b=c
@@ -314,7 +316,7 @@ Describe fern#internal#bufname
               \ 'query': {},
               \ 'fragment': '',
               \}
-        Assert Equals(fern#internal#bufname#parse(expr), want)
+        Assert Equals(fern#internal#bufname#parse(expr, cwd), want)
       End
 
       It returns FRI of fern://... from C:\foo\bar;a&b=c
@@ -326,7 +328,7 @@ Describe fern#internal#bufname
               \ 'query': {},
               \ 'fragment': '',
               \}
-        Assert Equals(fern#internal#bufname#parse(expr), want)
+        Assert Equals(fern#internal#bufname#parse(expr, cwd), want)
       End
 
       It returns FRI of fern://... from C:\foo\bar#foo\bar\hoge
@@ -338,7 +340,7 @@ Describe fern#internal#bufname
               \ 'query': {},
               \ 'fragment': '',
               \}
-        Assert Equals(fern#internal#bufname#parse(expr), want)
+        Assert Equals(fern#internal#bufname#parse(expr, cwd), want)
       End
 
       It returns FRI of fern://... from C:\foo\bar?a&b=c#foo\bar\hoge
@@ -350,7 +352,7 @@ Describe fern#internal#bufname
               \ 'query': {},
               \ 'fragment': '',
               \}
-        Assert Equals(fern#internal#bufname#parse(expr), want)
+        Assert Equals(fern#internal#bufname#parse(expr, cwd), want)
       End
 
       It returns FRI of fern://... from C:\foo\bar;a&b=c#foo\bar\hoge
@@ -362,7 +364,7 @@ Describe fern#internal#bufname
               \ 'query': {},
               \ 'fragment': '',
               \}
-        Assert Equals(fern#internal#bufname#parse(expr), want)
+        Assert Equals(fern#internal#bufname#parse(expr, cwd), want)
       End
     End
   End

--- a/test/fern/internal/filepath.vimspec
+++ b/test/fern/internal/filepath.vimspec
@@ -1,0 +1,291 @@
+Describe fern#internal#filepath
+  Before all
+    let fern_internal_filepath_is_windows = g:fern#internal#filepath#is_windows
+  End
+
+  After all
+    let g:fern#internal#filepath#is_windows = fern_internal_filepath_is_windows
+  End
+
+  Context Unix
+    Before
+      let g:fern#internal#filepath#is_windows = 0
+    End
+
+    Describe #is_absolute()
+      It returns 1 for '/usr/local'
+        Assert True(fern#internal#filepath#is_absolute('/usr/local'))
+      End
+
+      It returns 1 for '/'
+        Assert True(fern#internal#filepath#is_absolute('/'))
+      End
+
+      It returns 1 for '' (to keep behavior consistency to Windows)
+        Assert True(fern#internal#filepath#is_absolute(''))
+      End
+
+      It returns 0 for 'usr/local'
+        Assert False(fern#internal#filepath#is_absolute('usr/local'))
+      End
+
+      It returns 0 for 'usr'
+        Assert False(fern#internal#filepath#is_absolute('usr'))
+      End
+    End
+
+    Describe #to_slash()
+      It returns an absolute path ('/usr/local' -> '/usr/local')
+        let path = '/usr/local'
+        let want = '/usr/local'
+        let got = fern#internal#filepath#to_slash(path)
+        Assert Equals(got, want)
+      End
+
+      It returns a relative path ('usr/local' -> 'usr/local')
+        let path = 'usr/local'
+        let want = 'usr/local'
+        let got = fern#internal#filepath#to_slash(path)
+        Assert Equals(got, want)
+      End
+
+      It removes duplicate slashes ('/usr//local' -> '/usr/local')
+        let path = '/usr//local'
+        let want = '/usr/local'
+        let got = fern#internal#filepath#to_slash(path)
+        Assert Equals(got, want)
+
+        let path = '/usr///local'
+        let want = '/usr/local'
+        let got = fern#internal#filepath#to_slash(path)
+        Assert Equals(got, want)
+      End
+
+      It removes trailing slashes ('/usr/local/' -> '/usr/local')
+        let path = '/usr/local/'
+        let want = '/usr/local'
+        let got = fern#internal#filepath#to_slash(path)
+        Assert Equals(got, want)
+
+        let path = '/usr/local//'
+        let want = '/usr/local'
+        let got = fern#internal#filepath#to_slash(path)
+        Assert Equals(got, want)
+      End
+
+      It does not remove a root slash ('/' -> '/')
+        let path = '/'
+        let want = '/'
+        let got = fern#internal#filepath#to_slash(path)
+        Assert Equals(got, want)
+      End
+
+      It return a root for an empty string ('' -> '/')
+        let path = ''
+        let want = '/'
+        let got = fern#internal#filepath#to_slash(path)
+        Assert Equals(got, want)
+      End
+    End
+
+    Describe #from_slash()
+      It returns an absolute path ('/usr/local' -> '/usr/local')
+        let path = '/usr/local'
+        let want = '/usr/local'
+        let got = fern#internal#filepath#from_slash(path)
+        Assert Equals(got, want)
+      End
+
+      It returns a relative path ('usr/local' -> 'usr/local')
+        let path = 'usr/local'
+        let want = 'usr/local'
+        let got = fern#internal#filepath#from_slash(path)
+        Assert Equals(got, want)
+      End
+
+      It removes duplicate slashes ('/usr//local' -> '/usr/local')
+        let path = '/usr//local'
+        let want = '/usr/local'
+        let got = fern#internal#filepath#from_slash(path)
+        Assert Equals(got, want)
+
+        let path = '/usr///local'
+        let want = '/usr/local'
+        let got = fern#internal#filepath#from_slash(path)
+        Assert Equals(got, want)
+      End
+
+      It removes trailing slashes ('/usr/local/' -> '/usr/local')
+        let path = '/usr/local/'
+        let want = '/usr/local'
+        let got = fern#internal#filepath#from_slash(path)
+        Assert Equals(got, want)
+
+        let path = '/usr/local//'
+        let want = '/usr/local'
+        let got = fern#internal#filepath#from_slash(path)
+        Assert Equals(got, want)
+      End
+
+      It does not remove a root slash ('/' -> '/')
+        let path = '/'
+        let want = '/'
+        let got = fern#internal#filepath#from_slash(path)
+        Assert Equals(got, want)
+      End
+
+      It return a root for an empty string ('' -> '/')
+        let path = ''
+        let want = '/'
+        let got = fern#internal#filepath#from_slash(path)
+        Assert Equals(got, want)
+      End
+    End
+  End
+
+  Context Windows
+    Before
+      let g:fern#internal#filepath#is_windows = 1
+    End
+
+    Describe #is_absolute()
+      It returns 1 for 'C:\Windows\System32'
+        Assert True(fern#internal#filepath#is_absolute('C:\Windows\System32'))
+      End
+
+      It returns 1 for 'C:\' (a drive root)
+        Assert True(fern#internal#filepath#is_absolute('C:\'))
+      End
+
+      It returns 1 for '' (a root)
+        Assert True(fern#internal#filepath#is_absolute(''))
+      End
+
+      It returns 0 for 'Windows\System32'
+        Assert False(fern#internal#filepath#is_absolute('Windows\System32'))
+      End
+
+      It returns 0 for 'Windows'
+        Assert False(fern#internal#filepath#is_absolute('Windows'))
+      End
+    End
+
+    Describe #to_slash()
+      It returns a slash separated absolute path ('C:\Windows\System32' -> '/C:/Windows/System32')
+        let path = 'C:\Windows\System32'
+        let want = '/C:/Windows/System32'
+        let got = fern#internal#filepath#to_slash(path)
+        Assert Equals(got, want)
+      End
+
+      It returns a slash separated relative path ('Windows\System32' for 'Windows/System32')
+        let path = 'Windows\System32'
+        let want = 'Windows/System32'
+        let got = fern#internal#filepath#to_slash(path)
+        Assert Equals(got, want)
+      End
+
+      It removes duplicate baskslashes ('C:\Windows\\System32' -> '/C:/Windows/System32')
+        let path = 'C:\Windows\\System32'
+        let want = '/C:/Windows/System32'
+        let got = fern#internal#filepath#to_slash(path)
+        Assert Equals(got, want)
+
+        let path = 'C:\Windows\\\System32'
+        let want = '/C:/Windows/System32'
+        let got = fern#internal#filepath#to_slash(path)
+        Assert Equals(got, want)
+      End
+
+      It removes trailing baskslashes ('C:\Windows\System32\' -> '/C:/Windows/System32')
+        let path = 'C:\Windows\System32\'
+        let want = '/C:/Windows/System32'
+        let got = fern#internal#filepath#to_slash(path)
+        Assert Equals(got, want)
+
+        let path = 'C:\Windows\System32\\'
+        let want = '/C:/Windows/System32'
+        let got = fern#internal#filepath#to_slash(path)
+        Assert Equals(got, want)
+      End
+
+      It removes a backslash of a drive root ('C:\' -> '/C:')
+        let path = 'C:\'
+        let want = '/C:'
+        let got = fern#internal#filepath#to_slash(path)
+        Assert Equals(got, want)
+
+        let path = ''
+        let want = '/'
+        let got = fern#internal#filepath#to_slash(path)
+        Assert Equals(got, want)
+      End
+
+      It returns a root for an empty string ('' -> '/')
+        let path = ''
+        let want = '/'
+        let got = fern#internal#filepath#to_slash(path)
+        Assert Equals(got, want)
+      End
+    End
+
+    Describe #from_slash()
+      It returns a baskslash separated absolute path ('/C:/Windows/System32' -> 'C:\Windows\System32')
+        let path = '/C:/Windows/System32'
+        let want = 'C:\Windows\System32'
+        let got = fern#internal#filepath#from_slash(path)
+        Assert Equals(got, want)
+      End
+
+      It returns a backslash separated relative path ('Windows/System32' -> 'Windows\System32')
+        let path = 'Windows/System32'
+        let want = 'Windows\System32'
+        let got = fern#internal#filepath#from_slash(path)
+        Assert Equals(got, want)
+      End
+
+      It removes duplicate slashes ('/C:/Windows//System32' -> 'C:\Windows\System32')
+        let path = '/C:/Windows//System32'
+        let want = 'C:\Windows\System32'
+        let got = fern#internal#filepath#from_slash(path)
+        Assert Equals(got, want)
+
+        let path = '/C:/Windows///System32'
+        let want = 'C:\Windows\System32'
+        let got = fern#internal#filepath#from_slash(path)
+        Assert Equals(got, want)
+      End
+
+      It removes trailing baskslashes ('/C:/Windows/System32/' -> 'C:\Windows\System32')
+        let path = '/C:/Windows/System32/'
+        let want = 'C:\Windows\System32'
+        let got = fern#internal#filepath#from_slash(path)
+        Assert Equals(got, want)
+
+        let path = '/C:/Windows/System32//'
+        let want = 'C:\Windows\System32'
+        let got = fern#internal#filepath#from_slash(path)
+        Assert Equals(got, want)
+      End
+
+      It does not remove a trailing baskslash of a drive root ('/C:/' -> 'C:\')
+        let path = '/C:/'
+        let want = 'C:\'
+        let got = fern#internal#filepath#from_slash(path)
+        Assert Equals(got, want)
+
+        let path = '/C:'
+        let want = 'C:\'
+        let got = fern#internal#filepath#from_slash(path)
+        Assert Equals(got, want)
+      End
+
+      It returns an empty string for a root ('/' -> '')
+        let path = '/'
+        let want = ''
+        let got = fern#internal#filepath#from_slash(path)
+        Assert Equals(got, want)
+      End
+    End
+  End
+End

--- a/test/fern/internal/filepath.vimspec
+++ b/test/fern/internal/filepath.vimspec
@@ -12,28 +12,6 @@ Describe fern#internal#filepath
       let g:fern#internal#filepath#is_windows = 0
     End
 
-    Describe #is_absolute()
-      It returns 1 for '/usr/local'
-        Assert True(fern#internal#filepath#is_absolute('/usr/local'))
-      End
-
-      It returns 1 for '/'
-        Assert True(fern#internal#filepath#is_absolute('/'))
-      End
-
-      It returns 1 for '' (to keep behavior consistency to Windows)
-        Assert True(fern#internal#filepath#is_absolute(''))
-      End
-
-      It returns 0 for 'usr/local'
-        Assert False(fern#internal#filepath#is_absolute('usr/local'))
-      End
-
-      It returns 0 for 'usr'
-        Assert False(fern#internal#filepath#is_absolute('usr'))
-      End
-    End
-
     Describe #to_slash()
       It returns an absolute path ('/usr/local' -> '/usr/local')
         let path = '/usr/local'
@@ -141,33 +119,79 @@ Describe fern#internal#filepath
         Assert Equals(got, want)
       End
     End
+
+    Describe #is_root()
+      It returns 1 for '/'
+        let path = '/'
+        Assert True(fern#internal#filepath#is_root(path))
+      End
+
+      It returns 0 for ''
+        let path = ''
+        Assert False(fern#internal#filepath#is_root(path))
+      End
+
+      It returns 0 for '/usr/local'
+        let path = '/usr/local'
+        Assert False(fern#internal#filepath#is_root(path))
+      End
+    End
+
+    Describe #is_drive_root()
+      It returns 1 for '/'
+        let path = '/'
+        Assert True(fern#internal#filepath#is_drive_root(path))
+      End
+
+      It returns 0 for ''
+        let path = ''
+        Assert False(fern#internal#filepath#is_drive_root(path))
+      End
+
+      It returns 0 for '/usr/local'
+        let path = '/usr/local'
+        Assert False(fern#internal#filepath#is_drive_root(path))
+      End
+    End
+
+    Describe #is_absolute()
+      It returns 1 for '/usr/local'
+        Assert True(fern#internal#filepath#is_absolute('/usr/local'))
+      End
+
+      It returns 1 for '/'
+        Assert True(fern#internal#filepath#is_absolute('/'))
+      End
+
+      It returns 1 for '' (to keep behavior consistency to Windows)
+        Assert True(fern#internal#filepath#is_absolute(''))
+      End
+
+      It returns 0 for 'usr/local'
+        Assert False(fern#internal#filepath#is_absolute('usr/local'))
+      End
+
+      It returns 0 for 'usr'
+        Assert False(fern#internal#filepath#is_absolute('usr'))
+      End
+    End
+
+    Describe #join()
+      It returns a joined path
+        let paths = [
+              \ '/usr/local',
+              \ 'bin',
+              \]
+        let want = '/usr/local/bin'
+        let got = fern#internal#filepath#join(paths)
+        Assert Equals(got, want)
+      End
+    End
   End
 
   Context Windows
     Before
       let g:fern#internal#filepath#is_windows = 1
-    End
-
-    Describe #is_absolute()
-      It returns 1 for 'C:\Windows\System32'
-        Assert True(fern#internal#filepath#is_absolute('C:\Windows\System32'))
-      End
-
-      It returns 1 for 'C:\' (a drive root)
-        Assert True(fern#internal#filepath#is_absolute('C:\'))
-      End
-
-      It returns 1 for '' (a root)
-        Assert True(fern#internal#filepath#is_absolute(''))
-      End
-
-      It returns 0 for 'Windows\System32'
-        Assert False(fern#internal#filepath#is_absolute('Windows\System32'))
-      End
-
-      It returns 0 for 'Windows'
-        Assert False(fern#internal#filepath#is_absolute('Windows'))
-      End
     End
 
     Describe #to_slash()
@@ -284,6 +308,69 @@ Describe fern#internal#filepath
         let path = '/'
         let want = ''
         let got = fern#internal#filepath#from_slash(path)
+        Assert Equals(got, want)
+      End
+    End
+
+    Describe #is_root()
+      It returns 1 for ''
+        let path = ''
+        Assert True(fern#internal#filepath#is_root(path))
+      End
+
+      It returns 0 for 'C:\Windows\System32'
+        let path = 'C:\Windows\System32'
+        Assert False(fern#internal#filepath#is_root(path))
+      End
+    End
+
+    Describe #is_drive_root()
+      It returns 1 for 'C:\'
+        let path = 'C:\'
+        Assert True(fern#internal#filepath#is_drive_root(path))
+      End
+
+      It returns 0 for ''
+        let path = ''
+        Assert False(fern#internal#filepath#is_drive_root(path))
+      End
+
+      It returns 0 for 'C:\Windows\System32'
+        let path = 'C:\Windows\System32'
+        Assert False(fern#internal#filepath#is_drive_root(path))
+      End
+    End
+
+    Describe #is_absolute()
+      It returns 1 for 'C:\Windows\System32'
+        Assert True(fern#internal#filepath#is_absolute('C:\Windows\System32'))
+      End
+
+      It returns 1 for 'C:\' (a drive root)
+        Assert True(fern#internal#filepath#is_absolute('C:\'))
+      End
+
+      It returns 1 for '' (a root)
+        Assert True(fern#internal#filepath#is_absolute(''))
+      End
+
+      It returns 0 for 'Windows\System32'
+        Assert False(fern#internal#filepath#is_absolute('Windows\System32'))
+      End
+
+      It returns 0 for 'Windows'
+        Assert False(fern#internal#filepath#is_absolute('Windows'))
+      End
+    End
+
+    Describe #join()
+      It returns a joined path
+        let paths = [
+              \ 'C:\Windows\System32',
+              \ 'Foo',
+              \]
+        let want = 'C:\Windows\System32\Foo'
+        let got = fern#internal#filepath#join(paths)
         Assert Equals(got, want)
       End
     End

--- a/test/fern/internal/path.vimspec
+++ b/test/fern/internal/path.vimspec
@@ -1,58 +1,62 @@
 Describe fern#internal#path
   Describe #simplify()
     It removes empty segment from path
-      let val = ['foo', 'bar', '', 'hoge']
-      let exp = ['foo', 'bar', 'hoge']
+      let val = '/foo/bar//hoge'
+      let exp = '/foo/bar/hoge'
       Assert Equals(fern#internal#path#simplify(val), exp)
     End
 
     It removes '.' from path
-      let val = ['foo', '.', 'bar', '.', 'hoge']
-      let exp = ['foo', 'bar', 'hoge']
+      let val = '/foo/./bar/./hoge'
+      let exp = '/foo/bar/hoge'
       Assert Equals(fern#internal#path#simplify(val), exp)
     End
 
     It removes '..' and corresponding terms from path
-      let val = ['foo', '..', 'bar', '..', 'hoge']
-      let exp = ['hoge']
+      let val = '/foo/../bar/../hoge'
+      let exp = '/hoge'
       Assert Equals(fern#internal#path#simplify(val), exp)
 
-      let val = ['foo', '..', 'bar', '..', '..', 'hoge']
-      let exp = ['..', 'hoge']
+      let val = 'foo/../bar/../../hoge'
+      let exp = '../hoge'
       Assert Equals(fern#internal#path#simplify(val), exp)
 
-      let val = ['foo', '..', '..', 'bar', '..', '..', 'hoge']
-      let exp = ['..', '..', 'hoge']
+      let val = 'foo/../../bar/../../hoge'
+      let exp = '../../hoge'
       Assert Equals(fern#internal#path#simplify(val), exp)
     End
   End
 
   Describe #commonpath()
     It returns a relative path from a given base
-      let path = ['foo', 'bar', 'hoge', 'a', 'b', 'c']
-      let base = ['foo', 'bar', 'hoge']
-      let exp = ['foo', 'bar', 'hoge']
+      let path = '/foo/bar/hoge/a/b/c'
+      let base = '/foo/bar/hoge'
+      let exp = '/foo/bar/hoge'
       Assert Equals(fern#internal#path#commonpath([path, base]), exp)
 
-      let path = ['foo', 'bar', 'hoge', 'a', 'b', 'c']
-      let base = ['foo1', 'bar2', 'hoge3']
-      let exp = []
+      let path = '/foo/bar/hoge/a/b/c'
+      let base = '/foo1/bar2/hoge3'
+      let exp = ''
       Assert Equals(fern#internal#path#commonpath([path, base]), exp)
+    End
+
+    It throws error when non absolute path has specified
+      Throws /must be absolute/ fern#internal#path#commonpath(['foo/bar'])
     End
   End
 
   Describe #relative()
     It returns a relative path from a given base
-      let path = ['foo', 'bar', 'hoge']
-      let base = ['foo']
-      let exp = ['bar', 'hoge']
+      let path = '/foo/bar/hoge'
+      let base = '/foo'
+      let exp = 'bar/hoge'
       Assert Equals(fern#internal#path#relative(path, base), exp)
     End
 
     It return a path contains '..' if no common prefix exists
-      let path = ['foo', 'bar', 'hoge']
-      let base = ['piyo', 'puyo']
-      let exp = ['..', '..', 'foo', 'bar', 'hoge']
+      let path = '/foo/bar/hoge'
+      let base = '/piyo/puyo'
+      let exp = '../../foo/bar/hoge'
       Assert Equals(fern#internal#path#relative(path, base), exp)
     End
   End

--- a/test/fern/internal/path.vimspec
+++ b/test/fern/internal/path.vimspec
@@ -1,63 +1,246 @@
 Describe fern#internal#path
   Describe #simplify()
-    It removes empty segment from path
-      let val = '/foo/bar//hoge'
-      let exp = '/foo/bar/hoge'
-      Assert Equals(fern#internal#path#simplify(val), exp)
+    It returns an absolute path (/usr/local -> /usr/local)
+      let path = '/usr/local'
+      let want = '/usr/local'
+      let got = fern#internal#path#simplify(path)
+      Assert Equals(got, want)
     End
 
-    It removes '.' from path
-      let val = '/foo/./bar/./hoge'
-      let exp = '/foo/bar/hoge'
-      Assert Equals(fern#internal#path#simplify(val), exp)
+    It returns a relative path (usr/local -> usr/local)
+      let path = 'usr/local'
+      let want = 'usr/local'
+      let got = fern#internal#path#simplify(path)
+      Assert Equals(got, want)
     End
 
-    It removes '..' and corresponding terms from path
-      let val = '/foo/../bar/../hoge'
-      let exp = '/hoge'
-      Assert Equals(fern#internal#path#simplify(val), exp)
+    It removes duplicate slashes (/usr//local -> /usr/local)
+      let path = '/usr//local'
+      let want = '/usr/local'
+      let got = fern#internal#path#simplify(path)
+      Assert Equals(got, want)
 
-      let val = 'foo/../bar/../../hoge'
-      let exp = '../hoge'
-      Assert Equals(fern#internal#path#simplify(val), exp)
+      let path = '/usr///local'
+      let want = '/usr/local'
+      let got = fern#internal#path#simplify(path)
+      Assert Equals(got, want)
+    End
 
-      let val = 'foo/../../bar/../../hoge'
-      let exp = '../../hoge'
-      Assert Equals(fern#internal#path#simplify(val), exp)
+    It removes trailing slashes (/usr/local/ -> /usr/local)
+      let path = '/usr/local/'
+      let want = '/usr/local'
+      let got = fern#internal#path#simplify(path)
+      Assert Equals(got, want)
+
+      let path = '/usr/local//'
+      let want = '/usr/local'
+      let got = fern#internal#path#simplify(path)
+      Assert Equals(got, want)
+    End
+
+    It removes '.' (/usr/./local -> /usr/local)
+      let path = '/usr/./local'
+      let want = '/usr/local'
+      let got = fern#internal#path#simplify(path)
+      Assert Equals(got, want)
+
+      let path = '/usr/././local'
+      let want = '/usr/local'
+      let got = fern#internal#path#simplify(path)
+      Assert Equals(got, want)
+
+      let path = './usr/local'
+      let want = 'usr/local'
+      let got = fern#internal#path#simplify(path)
+      Assert Equals(got, want)
+    End
+
+    It removes '..' and corresponding components (/usr/../local -> /local)
+      let path = '/usr/../local'
+      let want = '/local'
+      let got = fern#internal#path#simplify(path)
+      Assert Equals(got, want)
+
+      let path = '../usr/local'
+      let want = '../usr/local'
+      let got = fern#internal#path#simplify(path)
+      Assert Equals(got, want)
+
+      let path = '/usr/../../local'
+      let want = '../local'
+      let got = fern#internal#path#simplify(path)
+      Assert Equals(got, want)
     End
   End
 
   Describe #commonpath()
-    It returns a relative path from a given base
-      let path = '/foo/bar/hoge/a/b/c'
-      let base = '/foo/bar/hoge'
-      let exp = '/foo/bar/hoge'
-      Assert Equals(fern#internal#path#commonpath([path, base]), exp)
-
-      let path = '/foo/bar/hoge/a/b/c'
-      let base = '/foo1/bar2/hoge3'
-      let exp = ''
-      Assert Equals(fern#internal#path#commonpath([path, base]), exp)
+    It throws an error when {paths} contains non absolute paths
+      let paths = [
+            \ 'usr/local',
+            \]
+      Throws /must be an absolute path/ fern#internal#path#commonpath(paths)
     End
 
-    It throws error when non absolute path has specified
-      Throws /must be absolute/ fern#internal#path#commonpath(['foo/bar'])
+    It returns a common path of among given {paths}
+      let paths = [
+            \ '/usr/local/bin/vim',
+            \ '/usr/local/openssh',
+            \ '/usr/bin/vim',
+            \]
+      let want = '/usr'
+      let got = fern#internal#path#commonpath(paths)
+      Assert Equals(got, want)
+    End
+
+    It returns '/' if no common path exists
+      let paths = [
+            \ '/usr/local/bin/vim',
+            \ '/usr/local/openssh',
+            \ '/vim',
+            \]
+      let want = '/'
+      let got = fern#internal#path#commonpath(paths)
+      Assert Equals(got, want)
+    End
+  End
+
+  Describe #absolute()
+    It throws an error when {base} is not absolute path
+      let base = 'home/fern'
+      let path = '/usr/local'
+      Throws /must be an absolute path/ fern#internal#path#absolute(path, base)
+    End
+
+    It returns an absolute path (/usr/local,/home/fern -> /usr/local)
+      let base = '/home/fern'
+      let path = '/usr/local'
+      let want = '/usr/local'
+      let got = fern#internal#path#absolute(path, base)
+      Assert Equals(got, want)
+    End
+
+    It returns an absolute path from the base (usr/local,/home/fern -> /home/fern/usr/local)
+      let base = '/home/fern'
+      let path = 'usr/local'
+      let want = '/home/fern/usr/local'
+      let got = fern#internal#path#absolute(path, base)
+      Assert Equals(got, want)
+    End
+
+    It returns a simplified absolute path from the base (../../usr/local,/home/fern -> /usr/local)
+      let base = '/home/fern'
+      let path = '../../usr/local'
+      let want = '/usr/local'
+      let got = fern#internal#path#absolute(path, base)
+      Assert Equals(got, want)
+    End
+
+    It throws an error when the path beyonds the base
+      let base = '/home/fern'
+      let path = '../../../usr/local'
+      Throws /beyonds/ fern#internal#path#absolute(path, base)
     End
   End
 
   Describe #relative()
-    It returns a relative path from a given base
-      let path = '/foo/bar/hoge'
-      let base = '/foo'
-      let exp = 'bar/hoge'
-      Assert Equals(fern#internal#path#relative(path, base), exp)
+    It throws an error when {base} is not absolute path
+      let base = 'home/fern'
+      let path = '/usr/local'
+      Throws /must be an absolute path/ fern#internal#path#relative(path, base)
     End
 
-    It return a path contains '..' if no common prefix exists
-      let path = '/foo/bar/hoge'
-      let base = '/piyo/puyo'
-      let exp = '../../foo/bar/hoge'
-      Assert Equals(fern#internal#path#relative(path, base), exp)
+    It returns a relative path (usr/local,/home/fern -> usr/local)
+      let base = '/home/fern'
+      let path = 'usr/local'
+      let want = 'usr/local'
+      let got = fern#internal#path#relative(path, base)
+      Assert Equals(got, want)
+    End
+
+    It returns a relative path from the base (/home/fern/usr/local,/home/fern -> /usr/local)
+      let base = '/home/fern'
+      let path = '/home/fern/usr/local'
+      let want = 'usr/local'
+      let got = fern#internal#path#relative(path, base)
+      Assert Equals(got, want)
+    End
+
+    It returns a simplified relative path from the base (/usr/local,/home/fern -> ../../usr/local)
+      let base = '/home/fern'
+      let path = '/usr/local'
+      let want = '../../usr/local'
+      let got = fern#internal#path#relative(path, base)
+      Assert Equals(got, want)
+    End
+  End
+
+  Describe #basename()
+    It returns '' if path is an empty string ('' -> '')
+      let path = ''
+      let want = ''
+      let got = fern#internal#path#basename(path)
+      Assert Equals(got, want)
+    End
+
+    It returns '/' if path is a root ('/' -> '/')
+      let path = '/'
+      let want = '/'
+      let got = fern#internal#path#basename(path)
+      Assert Equals(got, want)
+    End
+
+    It returns a last component of a {path} ('/usr/local' -> 'local')
+      let path = '/usr/local'
+      let want = 'local'
+      let got = fern#internal#path#basename(path)
+      Assert Equals(got, want)
+    End
+
+    It removes trailing slashes prior to get a last component of a {path} ('/usr/local/' -> 'local')
+      let path = '/usr/local/'
+      let want = 'local'
+      let got = fern#internal#path#basename(path)
+      Assert Equals(got, want)
+
+      let path = '/usr/local//'
+      let want = 'local'
+      let got = fern#internal#path#basename(path)
+      Assert Equals(got, want)
+    End
+  End
+
+  Describe #dirname()
+    It returns '' if path is an empty string ('' -> '')
+      let path = ''
+      let want = ''
+      let got = fern#internal#path#dirname(path)
+      Assert Equals(got, want)
+    End
+
+    It returns '/' if path is a root ('/' -> '/')
+      let path = '/'
+      let want = '/'
+      let got = fern#internal#path#dirname(path)
+      Assert Equals(got, want)
+    End
+
+    It removes a last component of a {path} ('/usr/local' -> '/usr')
+      let path = '/usr/local'
+      let want = '/usr'
+      let got = fern#internal#path#dirname(path)
+      Assert Equals(got, want)
+    End
+
+    It removes trailing slashes prior to remove a last component of a {path} ('/usr/local/' -> '/usr')
+      let path = '/usr/local/'
+      let want = '/usr'
+      let got = fern#internal#path#dirname(path)
+      Assert Equals(got, want)
+
+      let path = '/usr/local//'
+      let want = '/usr'
+      let got = fern#internal#path#dirname(path)
+      Assert Equals(got, want)
     End
   End
 End


### PR DESCRIPTION
Close #70 

- Improve path handling by a new path module
- Support drives in Windows
  - A parent node of `'C:\'` is `''` and it points drive root
  - Users have to use `file:///` scheme to specify a drive root like `:Fern file:///`

![Kapture 2020-02-17 at 1 26 09](https://user-images.githubusercontent.com/546312/74608453-8299a000-5124-11ea-9950-f8314e5af07c.gif)
