### PR TITLE
Keep hidden/include/exclude after enter/leave

### DIFF
--- a/autoload/fern/internal/buffer.vim
+++ b/autoload/fern/internal/buffer.vim
@@ -26,7 +26,7 @@ function! fern#internal#buffer#open(bufname, ...) abort
   if options.opener ==# 'select'
     let options.opener = 'edit'
     if fern#internal#window#select()
-      return
+      return 1
     endif
   else
     if options.locator

--- a/autoload/fern/internal/viewer.vim
+++ b/autoload/fern/internal/viewer.vim
@@ -14,7 +14,10 @@ function! fern#internal#viewer#init() abort
 endfunction
 
 function! s:open(bufname, options, resolve, reject) abort
-  call fern#internal#buffer#open(a:bufname . '$', a:options)
+  if fern#internal#buffer#open(a:bufname . '$', a:options)
+    call a:reject('Cancelled')
+    return
+  endif
   let b:fern_notifier = {
         \ 'resolve': a:resolve,
         \ 'reject': a:reject,

--- a/autoload/fern/internal/viewer.vim
+++ b/autoload/fern/internal/viewer.vim
@@ -7,9 +7,6 @@ function! fern#internal#viewer#open(fri, options) abort
 endfunction
 
 function! fern#internal#viewer#init() abort
-  if exists('b:fern') && !get(g:, 'fern_debug')
-    return s:Promise.resolve()
-  endif
   let bufnr = bufnr('%')
   return s:init()
         \.then({ -> s:notify(bufnr, v:null) })

--- a/plugin/fern.vim
+++ b/plugin/fern.vim
@@ -14,6 +14,9 @@ command! -bar -nargs=*
       \ call fern#internal#command#focus#command(<q-mods>, [<f-args>])
 
 function! s:BufReadCmd() abort
+  if exists('b:fern') && !get(g:, 'fern_debug')
+    return
+  endif
   call fern#internal#viewer#init()
         \.catch({ e -> fern#logger#error(e) })
 endfunction


### PR DESCRIPTION
Fixed #84. The status is **NOT** stored as a buffer name while

- Those status does NOT belongs to buffer/window, it belongs to `fern` instance which is isolated from buffer/window internally, thus technically it's bit difficult to store the value as a buffer name
- It would make people confused especially if `include/exclude` is applied to *a new fresh buffer* because of its buffer name, thus it should NOT stored as a buffer name to keep UX quality