### PR TITLE
Fix open:select action on Vim

### DIFF
--- a/autoload/fern/internal/window.vim
+++ b/autoload/fern/internal/window.vim
@@ -90,10 +90,10 @@ endfunction
 
 function! s:cnoremap_all(chars) abort
   for nr in range(256)
-    execute printf("silent! cnoremap \<buffer>\<silent> \<Char-%d> \<Nop>", nr)
+    silent! execute printf("cnoremap \<buffer>\<silent> \<Char-%d> \<Nop>", nr)
   endfor
   for char in a:chars
-    execute printf("silent! cnoremap \<buffer>\<silent> %s %s\<CR>", char, char)
+    silent! execute printf("cnoremap \<buffer>\<silent> %s %s\<CR>", char, char)
   endfor
   silent! cunmap <buffer> <Return>
   silent! cunmap <buffer> <Esc>
@@ -101,7 +101,7 @@ endfunction
 
 function! s:cunmap_all() abort
   for nr in range(256)
-    execute printf("silent! cunmap \<buffer> \<Char-%d>", nr)
+    silent! execute printf("cunmap \<buffer> \<Char-%d>", nr)
   endfor
 endfunction
 


### PR DESCRIPTION
Close #91

It seems the following code raise E474: Invalid argument sometime in Vim

    execute printf("silent! cunmap \<buffer> \<Char-%d>", nr)

But the following

    silent! execute printf("cunmap \<buffer> \<Char-%d>", nr)

Thus use former version to fix #91

<img width="636" alt="tmux 2020-03-12 04-16-00" src="https://user-images.githubusercontent.com/546312/76454557-39cdc200-6418-11ea-88f9-ec868231c319.png">
