### PR TITLE
Collapse nodes prior to modify (copy/move/remove/trash/rename)

### DIFF
--- a/autoload/fern/helper/async.vim
+++ b/autoload/fern/helper/async.vim
@@ -250,6 +250,30 @@ function! s:async_leave_tree_post(helper, saved) abort
 endfunction
 let s:async.leave_tree = funcref('s:async_leave_tree')
 
+function! s:async_collapse_modified_nodes(nodes) abort dict
+  let helper = self.helper
+  let fern = helper.fern
+  let ps = []
+  for node in a:nodes
+    if node.__owner is# v:null || node.status isnot# helper.STATUS_EXPANDED
+      continue
+    endif
+    let p = fern#internal#node#collapse(
+          \ node,
+          \ fern.nodes,
+          \ fern.provider,
+          \ fern.comparator,
+          \ fern.source.token,
+          \)
+          \.then({ ns -> self.update_nodes(ns) })
+    call add(ps, p)
+  endfor
+  let Profile = fern#profile#start('fern#helper:helper.async.collapse_modified_nodes')
+  return s:Promise.all(ps)
+        \.finally({ -> Profile() })
+endfunction
+let s:async.collapse_modified_nodes = funcref('s:async_collapse_modified_nodes')
+
 
 " Private
 function! s:enter(fern, node) abort

--- a/autoload/fern/scheme/dict/mapping.vim
+++ b/autoload/fern/scheme/dict/mapping.vim
@@ -108,6 +108,7 @@ function! s:map_copy(helper) abort
 
   let root = a:helper.sync.get_root_node()
   return s:Promise.resolve()
+        \.then({ -> s:collapse_nodes(a:helper, nodes) })
         \.then({ -> a:helper.async.reload_node(root.__key) })
         \.then({ -> a:helper.async.redraw() })
         \.then({ -> a:helper.sync.echo(printf('%d items are copied', processed)) })
@@ -136,6 +137,7 @@ function! s:map_move(helper) abort
 
   let root = a:helper.sync.get_root_node()
   return s:Promise.resolve()
+        \.then({ -> s:collapse_nodes(a:helper, nodes) })
         \.then({ -> a:helper.async.reload_node(root.__key) })
         \.then({ -> a:helper.async.redraw() })
         \.then({ -> a:helper.sync.echo(printf('%d items are moved', processed)) })
@@ -169,6 +171,7 @@ function! s:map_remove(helper) abort
   call provider._update_tree(tree)
   let root = a:helper.sync.get_root_node()
   return s:Promise.resolve()
+        \.then({ -> s:collapse_nodes(a:helper, nodes) })
         \.then({ -> a:helper.async.reload_node(root.__key) })
         \.then({ -> a:helper.async.redraw() })
         \.then({ -> a:helper.sync.echo(printf('%d items are removed', len(nodes))) })
@@ -201,4 +204,11 @@ function! s:map_edit_leaf(helper) abort
   return s:Promise.resolve()
         \.then({ -> a:helper.async.reload_node(root.__key) })
         \.then({ -> a:helper.async.redraw() })
+endfunction
+
+function! s:collapse_nodes(helper, nodes) abort
+  return s:Promise.all(map(
+        \ copy(a:nodes),
+        \ { -> a:helper.async.collapse_node(v:val.__key) },
+        \))
 endfunction

--- a/autoload/fern/scheme/dict/mapping.vim
+++ b/autoload/fern/scheme/dict/mapping.vim
@@ -166,7 +166,6 @@ function! s:map_remove(helper) abort
   for node in nodes
     echo printf('Delete %s', node._path)
     call fern#scheme#dict#tree#remove(tree, node._path)
-    let node.status = a:helper.STATUS_COLLAPSED
   endfor
   call provider._update_tree(tree)
   let root = a:helper.sync.get_root_node()

--- a/autoload/fern/scheme/dict/mapping.vim
+++ b/autoload/fern/scheme/dict/mapping.vim
@@ -108,7 +108,7 @@ function! s:map_copy(helper) abort
 
   let root = a:helper.sync.get_root_node()
   return s:Promise.resolve()
-        \.then({ -> s:collapse_nodes(a:helper, nodes) })
+        \.then({ -> a:helper.async.collapse_modified_nodes(nodes) })
         \.then({ -> a:helper.async.reload_node(root.__key) })
         \.then({ -> a:helper.async.redraw() })
         \.then({ -> a:helper.sync.echo(printf('%d items are copied', processed)) })
@@ -137,7 +137,7 @@ function! s:map_move(helper) abort
 
   let root = a:helper.sync.get_root_node()
   return s:Promise.resolve()
-        \.then({ -> s:collapse_nodes(a:helper, nodes) })
+        \.then({ -> a:helper.async.collapse_modified_nodes(nodes) })
         \.then({ -> a:helper.async.reload_node(root.__key) })
         \.then({ -> a:helper.async.redraw() })
         \.then({ -> a:helper.sync.echo(printf('%d items are moved', processed)) })
@@ -170,7 +170,7 @@ function! s:map_remove(helper) abort
   call provider._update_tree(tree)
   let root = a:helper.sync.get_root_node()
   return s:Promise.resolve()
-        \.then({ -> s:collapse_nodes(a:helper, nodes) })
+        \.then({ -> a:helper.async.collapse_modified_nodes(nodes) })
         \.then({ -> a:helper.async.reload_node(root.__key) })
         \.then({ -> a:helper.async.redraw() })
         \.then({ -> a:helper.sync.echo(printf('%d items are removed', len(nodes))) })
@@ -203,11 +203,4 @@ function! s:map_edit_leaf(helper) abort
   return s:Promise.resolve()
         \.then({ -> a:helper.async.reload_node(root.__key) })
         \.then({ -> a:helper.async.redraw() })
-endfunction
-
-function! s:collapse_nodes(helper, nodes) abort
-  return s:Promise.all(map(
-        \ copy(a:nodes),
-        \ { -> a:helper.async.collapse_node(v:val.__key) },
-        \))
 endfunction

--- a/autoload/fern/scheme/dict/mapping/clipboard.vim
+++ b/autoload/fern/scheme/dict/mapping/clipboard.vim
@@ -91,7 +91,7 @@ function! s:map_clipboard_paste(helper) abort
 
   let root = a:helper.sync.get_root_node()
   return s:Promise.resolve()
-        \.then({ -> s:collapse_nodes(a:helper, s:clipboard.candidates) })
+        \.then({ -> a:helper.async.collapse_modified_nodes(s:clipboard.candidates) })
         \.then({ -> a:helper.async.reload_node(root.__key) })
         \.then({ -> a:helper.async.redraw() })
         \.then({ -> a:helper.sync.echo(printf('%d items are proceeded', processed)) })
@@ -102,11 +102,4 @@ function! s:map_clipboard_clear(helper) abort
         \ 'mode': 'copy',
         \ 'candidates': [],
         \}
-endfunction
-
-function! s:collapse_nodes(helper, nodes) abort
-  return s:Promise.all(map(
-        \ copy(a:nodes),
-        \ { -> a:helper.async.collapse_node(v:val.__key) },
-        \))
 endfunction

--- a/autoload/fern/scheme/dict/mapping/clipboard.vim
+++ b/autoload/fern/scheme/dict/mapping/clipboard.vim
@@ -30,7 +30,7 @@ function! s:map_clipboard_move(helper) abort
   let nodes = a:helper.sync.get_selected_nodes()
   let s:clipboard = {
         \ 'mode': 'move',
-        \ 'candidates': map(copy(nodes), { _, v -> v._path }),
+        \ 'candidates': copy(nodes),
         \}
   return s:Promise.resolve()
         \.then({ -> a:helper.async.update_marks([]) })
@@ -42,7 +42,7 @@ function! s:map_clipboard_copy(helper) abort
   let nodes = a:helper.sync.get_selected_nodes()
   let s:clipboard = {
         \ 'mode': 'copy',
-        \ 'candidates': map(copy(nodes), { _, v -> v._path }),
+        \ 'candidates': copy(nodes),
         \}
   return s:Promise.resolve()
         \.then({ -> a:helper.async.update_marks([]) })
@@ -56,7 +56,7 @@ function! s:map_clipboard_paste(helper) abort
   endif
 
   if s:clipboard.mode ==# 'move'
-    let paths = copy(s:clipboard.candidates)
+    let paths = map(copy(s:clipboard.candidates), { -> v:val._path })
     let prompt = printf('The following %d nodes will be moved', len(paths))
     for path in paths[:5]
       let prompt .= "\n" . path
@@ -77,13 +77,13 @@ function! s:map_clipboard_paste(helper) abort
   let node = node.status isnot# a:helper.STATUS_EXPANDED ? node.__owner : node
   let processed = 0
   for src in s:clipboard.candidates
-    let dst = '/' . join(split(node._path . '/' . matchstr(src, '[^/]\+$'), '/'), '/')
+    let dst = '/' . join(split(node._path . '/' . matchstr(src._path, '[^/]\+$'), '/'), '/')
     if s:clipboard.mode ==# 'move'
-      echo printf('Move %s -> %s', src, dst)
-      call fern#scheme#dict#tree#move(tree, src, dst)
+      echo printf('Move %s -> %s', src._path, dst)
+      call fern#scheme#dict#tree#move(tree, src._path, dst)
     else
-      echo printf('Copy %s -> %s', src, dst)
-      call fern#scheme#dict#tree#copy(tree, src, dst)
+      echo printf('Copy %s -> %s', src._path, dst)
+      call fern#scheme#dict#tree#copy(tree, src._path, dst)
     endif
     let processed += 1
   endfor
@@ -91,6 +91,7 @@ function! s:map_clipboard_paste(helper) abort
 
   let root = a:helper.sync.get_root_node()
   return s:Promise.resolve()
+        \.then({ -> s:collapse_nodes(a:helper, s:clipboard.candidates) })
         \.then({ -> a:helper.async.reload_node(root.__key) })
         \.then({ -> a:helper.async.redraw() })
         \.then({ -> a:helper.sync.echo(printf('%d items are proceeded', processed)) })
@@ -101,4 +102,11 @@ function! s:map_clipboard_clear(helper) abort
         \ 'mode': 'copy',
         \ 'candidates': [],
         \}
+endfunction
+
+function! s:collapse_nodes(helper, nodes) abort
+  return s:Promise.all(map(
+        \ copy(a:nodes),
+        \ { -> a:helper.async.collapse_node(v:val.__key) },
+        \))
 endfunction

--- a/autoload/fern/scheme/dict/mapping/rename.vim
+++ b/autoload/fern/scheme/dict/mapping/rename.vim
@@ -37,7 +37,8 @@ endfunction
 
 function! s:map_rename(helper, opener) abort
   let root = a:helper.sync.get_root_node()
-  let Factory = { -> map(copy(a:helper.sync.get_selected_nodes()), { _, n -> n._path }) }
+  let nodes = a:helper.sync.get_selected_nodes()
+  let Factory = { -> map(copy(nodes), { -> v:val._path }) }
   let options = {
         \ 'opener': a:opener,
         \ 'cursor': [1, len(root._path) + 1],
@@ -47,6 +48,7 @@ function! s:map_rename(helper, opener) abort
   return fern#internal#renamer#rename(Factory, options)
         \.then({ r -> s:_map_rename(a:helper, r) })
         \.then({ n -> s:Lambda.let(ns, 'n', n) })
+        \.then({ -> s:collapse_nodes(a:helper, nodes) })
         \.then({ -> a:helper.async.reload_node(root.__key) })
         \.then({ -> a:helper.async.redraw() })
         \.then({ -> a:helper.sync.echo(printf('%d items are renamed', ns.n)) })
@@ -69,4 +71,11 @@ function! s:_map_rename(helper, result) abort
   endfor
   call provider._update_tree(provider._tree)
   return s:Promise.resolve(proceeded)
+endfunction
+
+function! s:collapse_nodes(helper, nodes) abort
+  return s:Promise.all(map(
+        \ copy(a:nodes),
+        \ { -> a:helper.async.collapse_node(v:val.__key) },
+        \))
 endfunction

--- a/autoload/fern/scheme/dict/mapping/rename.vim
+++ b/autoload/fern/scheme/dict/mapping/rename.vim
@@ -48,7 +48,7 @@ function! s:map_rename(helper, opener) abort
   return fern#internal#renamer#rename(Factory, options)
         \.then({ r -> s:_map_rename(a:helper, r) })
         \.then({ n -> s:Lambda.let(ns, 'n', n) })
-        \.then({ -> s:collapse_nodes(a:helper, nodes) })
+        \.then({ -> a:helper.async.collapse_modified_nodes(nodes) })
         \.then({ -> a:helper.async.reload_node(root.__key) })
         \.then({ -> a:helper.async.redraw() })
         \.then({ -> a:helper.sync.echo(printf('%d items are renamed', ns.n)) })
@@ -71,11 +71,4 @@ function! s:_map_rename(helper, result) abort
   endfor
   call provider._update_tree(provider._tree)
   return s:Promise.resolve(proceeded)
-endfunction
-
-function! s:collapse_nodes(helper, nodes) abort
-  return s:Promise.all(map(
-        \ copy(a:nodes),
-        \ { -> a:helper.async.collapse_node(v:val.__key) },
-        \))
 endfunction

--- a/autoload/fern/scheme/file/mapping.vim
+++ b/autoload/fern/scheme/file/mapping.vim
@@ -113,7 +113,7 @@ function! s:map_copy(helper) abort
   endfor
   let root = a:helper.sync.get_root_node()
   return s:Promise.all(ps)
-        \.then({ -> s:collapse_nodes(a:helper, nodes) })
+        \.then({ -> a:helper.async.collapse_modified_nodes(nodes) })
         \.then({ -> a:helper.async.reload_node(root.__key) })
         \.then({ -> a:helper.async.redraw() })
         \.then({ -> a:helper.sync.echo(printf('%d items are copied', len(ps))) })
@@ -137,7 +137,7 @@ function! s:map_move(helper) abort
   endfor
   let root = a:helper.sync.get_root_node()
   return s:Promise.all(ps)
-        \.then({ -> s:collapse_nodes(a:helper, nodes) })
+        \.then({ -> a:helper.async.collapse_modified_nodes(nodes) })
         \.then({ -> a:helper.async.reload_node(root.__key) })
         \.then({ -> a:helper.async.redraw() })
         \.then({ -> a:helper.sync.echo(printf('%d items are moved', len(ps))) })
@@ -165,7 +165,7 @@ function! s:map_trash(helper) abort
   endfor
   let root = a:helper.sync.get_root_node()
   return s:Promise.all(ps)
-        \.then({ -> s:collapse_nodes(a:helper, nodes) })
+        \.then({ -> a:helper.async.collapse_modified_nodes(nodes) })
         \.then({ -> a:helper.async.reload_node(root.__key) })
         \.then({ -> a:helper.async.redraw() })
         \.then({ -> a:helper.sync.echo(printf('%d items are trashed', len(ps))) })
@@ -193,15 +193,8 @@ function! s:map_remove(helper) abort
   endfor
   let root = a:helper.sync.get_root_node()
   return s:Promise.all(ps)
-        \.then({ -> s:collapse_nodes(a:helper, nodes) })
+        \.then({ -> a:helper.async.collapse_modified_nodes(nodes) })
         \.then({ -> a:helper.async.reload_node(root.__key) })
         \.then({ -> a:helper.async.redraw() })
         \.then({ -> a:helper.sync.echo(printf('%d items are removed', len(ps))) })
-endfunction
-
-function! s:collapse_nodes(helper, nodes) abort
-  return s:Promise.all(map(
-        \ copy(a:nodes),
-        \ { -> a:helper.async.collapse_node(v:val.__key) },
-        \))
 endfunction

--- a/autoload/fern/scheme/file/mapping.vim
+++ b/autoload/fern/scheme/file/mapping.vim
@@ -162,7 +162,6 @@ function! s:map_trash(helper) abort
   for node in nodes
     echo printf('Trash %s', node._path)
     call add(ps, fern#scheme#file#shutil#trash(node._path, token))
-    let node.status = a:helper.STATUS_COLLAPSED
   endfor
   let root = a:helper.sync.get_root_node()
   return s:Promise.all(ps)
@@ -191,7 +190,6 @@ function! s:map_remove(helper) abort
   for node in nodes
     echo printf('Remove %s', node._path)
     call add(ps, fern#scheme#file#shutil#remove(node._path, token))
-    let node.status = a:helper.STATUS_COLLAPSED
   endfor
   let root = a:helper.sync.get_root_node()
   return s:Promise.all(ps)

--- a/autoload/fern/scheme/file/mapping.vim
+++ b/autoload/fern/scheme/file/mapping.vim
@@ -113,6 +113,7 @@ function! s:map_copy(helper) abort
   endfor
   let root = a:helper.sync.get_root_node()
   return s:Promise.all(ps)
+        \.then({ -> s:collapse_nodes(a:helper, nodes) })
         \.then({ -> a:helper.async.reload_node(root.__key) })
         \.then({ -> a:helper.async.redraw() })
         \.then({ -> a:helper.sync.echo(printf('%d items are copied', len(ps))) })
@@ -136,6 +137,7 @@ function! s:map_move(helper) abort
   endfor
   let root = a:helper.sync.get_root_node()
   return s:Promise.all(ps)
+        \.then({ -> s:collapse_nodes(a:helper, nodes) })
         \.then({ -> a:helper.async.reload_node(root.__key) })
         \.then({ -> a:helper.async.redraw() })
         \.then({ -> a:helper.sync.echo(printf('%d items are moved', len(ps))) })
@@ -164,6 +166,7 @@ function! s:map_trash(helper) abort
   endfor
   let root = a:helper.sync.get_root_node()
   return s:Promise.all(ps)
+        \.then({ -> s:collapse_nodes(a:helper, nodes) })
         \.then({ -> a:helper.async.reload_node(root.__key) })
         \.then({ -> a:helper.async.redraw() })
         \.then({ -> a:helper.sync.echo(printf('%d items are trashed', len(ps))) })
@@ -192,7 +195,15 @@ function! s:map_remove(helper) abort
   endfor
   let root = a:helper.sync.get_root_node()
   return s:Promise.all(ps)
+        \.then({ -> s:collapse_nodes(a:helper, nodes) })
         \.then({ -> a:helper.async.reload_node(root.__key) })
         \.then({ -> a:helper.async.redraw() })
         \.then({ -> a:helper.sync.echo(printf('%d items are removed', len(ps))) })
+endfunction
+
+function! s:collapse_nodes(helper, nodes) abort
+  return s:Promise.all(map(
+        \ copy(a:nodes),
+        \ { -> a:helper.async.collapse_node(v:val.__key) },
+        \))
 endfunction

--- a/autoload/fern/scheme/file/mapping/clipboard.vim
+++ b/autoload/fern/scheme/file/mapping/clipboard.vim
@@ -30,7 +30,7 @@ function! s:map_clipboard_move(helper) abort
   let nodes = a:helper.sync.get_selected_nodes()
   let s:clipboard = {
         \ 'mode': 'move',
-        \ 'candidates': map(copy(nodes), { _, v -> v._path }),
+        \ 'candidates': copy(nodes),
         \}
   return s:Promise.resolve()
         \.then({ -> a:helper.async.update_marks([]) })
@@ -42,7 +42,7 @@ function! s:map_clipboard_copy(helper) abort
   let nodes = a:helper.sync.get_selected_nodes()
   let s:clipboard = {
         \ 'mode': 'copy',
-        \ 'candidates': map(copy(nodes), { _, v -> v._path }),
+        \ 'candidates': copy(nodes),
         \}
   return s:Promise.resolve()
         \.then({ -> a:helper.async.update_marks([]) })
@@ -56,7 +56,7 @@ function! s:map_clipboard_paste(helper) abort
   endif
 
   if s:clipboard.mode ==# 'move'
-    let paths = copy(s:clipboard.candidates)
+    let paths = map(copy(s:clipboard.candidates), { -> v:val._path })
     let prompt = printf('The following %d nodes will be moved', len(paths))
     for path in paths[:5]
       let prompt .= "\n" . path
@@ -64,7 +64,7 @@ function! s:map_clipboard_paste(helper) abort
     if len(paths) > 5
       let prompt .= "\n..."
     endif
-    let prompt .= "\nAre you sure to continue (Y[es]/no): "
+    let prompt .= "\nAre you sure to continue (y[es]/n[o]): "
     if !s:Prompt.confirm(prompt)
       return s:Promise.reject('Cancelled')
     endif
@@ -76,19 +76,20 @@ function! s:map_clipboard_paste(helper) abort
   let token = a:helper.fern.source.token
   let ps = []
   for src in s:clipboard.candidates
-    let name = fern#internal#filepath#to_slash(src)
+    let name = fern#internal#filepath#to_slash(src._path)
     let name = fern#internal#path#basename(name)
     let dst = fern#internal#filepath#from_slash(join([base, name], '/'))
     if s:clipboard.mode ==# 'move'
-      echo printf('Move %s -> %s', src, dst)
-      call add(ps, fern#scheme#file#shutil#move(src, dst, token))
+      echo printf('Move %s -> %s', src._path, dst)
+      call add(ps, fern#scheme#file#shutil#move(src._path, dst, token))
     else
-      echo printf('Copy %s -> %s', src, dst)
-      call add(ps, fern#scheme#file#shutil#copy(src, dst, token))
+      echo printf('Copy %s -> %s', src._path, dst)
+      call add(ps, fern#scheme#file#shutil#copy(src._path, dst, token))
     endif
   endfor
   let root = a:helper.sync.get_root_node()
   return s:Promise.all(ps)
+        \.then({ -> s:collapse_nodes(a:helper, s:clipboard.candidates) })
         \.then({ -> a:helper.async.reload_node(root.__key) })
         \.then({ -> a:helper.async.redraw() })
         \.then({ -> a:helper.sync.echo(printf('%d items are proceeded', len(ps))) })
@@ -99,4 +100,11 @@ function! s:map_clipboard_clear(helper) abort
         \ 'mode': 'copy',
         \ 'candidates': [],
         \}
+endfunction
+
+function! s:collapse_nodes(helper, nodes) abort
+  return s:Promise.all(map(
+        \ copy(a:nodes),
+        \ { -> a:helper.async.collapse_node(v:val.__key) },
+        \))
 endfunction

--- a/autoload/fern/scheme/file/mapping/clipboard.vim
+++ b/autoload/fern/scheme/file/mapping/clipboard.vim
@@ -89,7 +89,7 @@ function! s:map_clipboard_paste(helper) abort
   endfor
   let root = a:helper.sync.get_root_node()
   return s:Promise.all(ps)
-        \.then({ -> s:collapse_nodes(a:helper, s:clipboard.candidates) })
+        \.then({ -> a:helper.async.collapse_modified_nodes(s:clipboard.candidates) })
         \.then({ -> a:helper.async.reload_node(root.__key) })
         \.then({ -> a:helper.async.redraw() })
         \.then({ -> a:helper.sync.echo(printf('%d items are proceeded', len(ps))) })
@@ -100,11 +100,4 @@ function! s:map_clipboard_clear(helper) abort
         \ 'mode': 'copy',
         \ 'candidates': [],
         \}
-endfunction
-
-function! s:collapse_nodes(helper, nodes) abort
-  return s:Promise.all(map(
-        \ copy(a:nodes),
-        \ { -> a:helper.async.collapse_node(v:val.__key) },
-        \))
 endfunction

--- a/autoload/fern/scheme/file/mapping/rename.vim
+++ b/autoload/fern/scheme/file/mapping/rename.vim
@@ -48,7 +48,7 @@ function! s:map_rename(helper, opener) abort
   return fern#internal#renamer#rename(Factory, options)
         \.then({ r -> s:_map_rename(a:helper, r) })
         \.then({ n -> s:Lambda.let(ns, 'n', n) })
-        \.then({ -> s:collapse_nodes(a:helper, nodes) })
+        \.then({ -> a:helper.async.collapse_modified_nodes(nodes) })
         \.then({ -> a:helper.async.reload_node(root.__key) })
         \.then({ -> a:helper.async.redraw() })
         \.then({ -> a:helper.sync.echo(printf('%d items are renamed', ns.n)) })
@@ -69,11 +69,4 @@ function! s:_map_rename(helper, result) abort
   endfor
   return s:Promise.all(ps)
         \.then({ -> len(ps) })
-endfunction
-
-function! s:collapse_nodes(helper, nodes) abort
-  return s:Promise.all(map(
-        \ copy(a:nodes),
-        \ { -> a:helper.async.collapse_node(v:val.__key) },
-        \))
 endfunction

--- a/doc/fern-develop.txt
+++ b/doc/fern-develop.txt
@@ -492,6 +492,13 @@ Following methods are executed asynchronously and return a promise.
 	Note that "bufname" of the parent node must be properly configured to
 	use this feature.
 
+			*fern-develop-helper.async.collapse_modified_nodes()*
+.async.collapse_modified_nodes({nodes})
+	Return a promise to collapse {nodes}.
+	It does NOT reload the node instead when the node has collapsed or
+	leaf, not like |fern-develop-helper.async.collapse_node()|.
+	It is used to collapse modified nodes to solve issue #103.
+
 
 =============================================================================
 LOGGER						*fern-develop-logger*


### PR DESCRIPTION
Close #103

Note that it's nearly impossible to correctly reload expanded nodes thus collapse these instead.