### PR TITLE
RFC: Add fern#smart#ready() to support await like mapping call

### DIFF
--- a/autoload/fern/hook.vim
+++ b/autoload/fern/hook.vim
@@ -1,3 +1,4 @@
+let s:Promise = vital#fern#import('Async.Promise')
 let s:hooks = {}
 
 function! fern#hook#add(name, callback, ...) abort
@@ -43,4 +44,8 @@ function! fern#hook#emit(name, ...) abort
     endtry
   endfor
   let s:hooks[a:name] = keeps
+endfunction
+
+function! fern#hook#promise(name) abort
+  return s:Promise.new({ r -> fern#hook#add(a:name, r, { 'once': v:true }) })
 endfunction

--- a/autoload/fern/internal/command/fern.vim
+++ b/autoload/fern/internal/command/fern.vim
@@ -76,7 +76,7 @@ function! fern#internal#command#fern#command(mods, fargs) abort
 
     let wait_count = []
     if wait
-      call fern#hook#add('read', { -> add(wait_count, 1) }, {
+      call fern#hook#add('viewer:ready', { -> add(wait_count, 1) }, {
             \ 'once': v:true,
             \})
     endif

--- a/autoload/fern/internal/viewer.vim
+++ b/autoload/fern/internal/viewer.vim
@@ -84,7 +84,7 @@ function! s:init() abort
           \.finally({ -> Profile('redraw') })
           \.then({ -> helper.sync.focus_node(reveal) })
           \.finally({ -> Profile() })
-          \.then({ -> fern#hook#emit('read', helper) })
+          \.then({ -> fern#hook#emit('viewer:ready', helper) })
   catch
     return s:Promise.reject(v:exception)
   endtry
@@ -112,7 +112,7 @@ function! s:BufReadCmd() abort
         \.then({ -> helper.sync.set_cursor(cursor[1:2]) })
         \.then({ -> helper.async.reload_node(root.__key) })
         \.then({ -> helper.async.redraw() })
-        \.then({ -> fern#hook#emit('read', helper) })
+        \.then({ -> fern#hook#emit('viewer:ready', helper) })
         \.catch({ e -> fern#logger#error(e) })
 endfunction
 

--- a/autoload/fern/smart.vim
+++ b/autoload/fern/smart.vim
@@ -1,3 +1,7 @@
+let s:Promise = vital#fern#import('Async.Promise')
+
+
+" For <expr> mappings
 function! fern#smart#leaf(leaf, branch, ...) abort
   let helper = fern#helper#new()
   let node = helper.sync.get_cursor_node()
@@ -27,4 +31,25 @@ function! fern#smart#scheme(default, schemes) abort
     return a:schemes[scheme]
   endif
   return a:default
+endfunction
+
+
+" For NON <expr> mappings
+function! fern#smart#ready(expr, ...) abort
+  let options = extend({
+        \ 'timeout': 500,
+        \}, a:0 ? a:1 : {},
+        \)
+  call s:Promise.race([
+        \ fern#hook#promise('viewer:ready'),
+        \ fern#util#sleep(options.timeout)
+        \])
+        \.then({ -> execute(printf('normal %s', a:expr)) })
+  return s:warn_on_expr_mapping(
+        \ 'fern#smart#ready() cannot used in <expr> mapping',
+        \)
+endfunction
+
+function! s:warn_on_expr_mapping(message) abort
+  return printf("\<Esc>:echoerr '[fern] %s'\<CR>", escape(a:message, "'"))
 endfunction

--- a/doc/fern.txt
+++ b/doc/fern.txt
@@ -449,6 +449,27 @@ fern#smart#scheme({default}, {schemes})
 	      \   },
 	      \ )
 <
+							*fern#smart#ready()*
+fern#smart#ready({expr}[, {options}])
+	Execute an {expr} as a normal mapping once fern buffer has become
+	ready. If no unready fern buffer exists when the function has called,
+	it waits {options.timeout} then execute the {expr}.
+	Note that this function is NOT for |:map-<expr>| thus use it as a
+	normal function (e.g. ":<C-u>call fern#smart#ready(...)")
+>
+	" Create a new mapping which execute 'tcd:root' action once fern
+	" buffer has become ready
+	nnoremap <buffer><silent> <Plug>(fern-tcd-on-ready)
+	      \ :<C-u>call fern#smart#ready(
+	      \   "\<Plug>(fern-action-tcd:root)",
+	      \   { 'timeout': 500 },
+	      \ )<CR>
+
+	" Use above mapping to automatically execute tcd after enter
+	nmap <buffer> <Plug>(fern-enter-and-tcd)
+	      \ <Plug>(fern-action-enter)
+	      \ <Plug>(fern-tcd-on-ready)
+<
 
 
 =============================================================================


### PR DESCRIPTION
To solve #107, `fern#smart#ready()` function has added. The function invoke a given expression once a fern buffer become ready thus users do not need to care the asynchronous calls.

To execute `tcd:root` action every after `enter/leave` action, first define `<Plug>(my-fern-tcd-on-ready)` action like

```vim
nnoremap <buffer><silent> <Plug>(my-fern-tcd-on-ready)
      \ :<C-u>call fern#smart#ready("\<Plug>(fern-action-tcd:root)")<CR>
```

Then, create `<Plug>(my-fern-enter-or-tcd)/<Plug>(my-fern-leave-or-tcd)` like

```vim
nmap <buffer> <Plug>(my-fern-enter-or-tcd)
      \ <Plug>(fern-action-enter)<Plug>(my-fern-tcd-on-ready)
nmap <buffer> <Plug>(my-fern-leave-or-tcd)
      \ <Plug>(fern-action-leave)<Plug>(my-fern-tcd-on-ready)
```

Top-Left indicates current working directory. The cwd changes when the root directory has changed.

![Kapture 2020-06-12 at 2 25 30](https://user-images.githubusercontent.com/546312/84419751-04718400-ac54-11ea-8493-89e3a5c992bf.gif)

<details>
<summary>More complex mapping example for change behavior on drawer/window</summary>

```vim
function! s:fern_init() abort
  nnoremap <buffer><silent>
       \ <Plug>(fern-my-tcd:root-ready)
       \ :<C-u>call fern#smart#ready("\<Plug>(fern-action-tcd:root)")<CR>
  nmap <buffer>
        \ <Plug>(fern-my-enter-and-tcd)
        \ <Plug>(fern-action-enter)<Plug>(fern-my-tcd:root-ready)
  nmap <buffer>
        \ <Plug>(fern-my-leave-and-tcd)
        \ <Plug>(fern-action-leave)<Plug>(fern-my-tcd:root-ready)

  nmap <buffer><expr>
        \ <Plug>(fern-my-open-or-enter-and-tcd)
        \ fern#smart#leaf(
        \   "\<Plug>(fern-action-open)",
        \   "\<Plug>(fern-my-enter-and-tcd)",
        \ )

  nmap <buffer><expr>
        \ <Plug>(fern-my-open-or-enter)
        \ fern#smart#drawer(
        \   "\<Plug>(fern-my-open-or-enter-and-tcd)",
        \   "\<Plug>(fern-open-or-enter)",
        \ )
  nmap <buffer><expr>
        \ <Plug>(fern-my-leave)
        \ fern#smart#drawer(
        \   "\<Plug>(fern-my-leave-and-tcd)",
        \   "\<Plug>(fern-action-leave)",
        \ )
  nmap <buffer><nowait> <Return> <Plug>(fern-my-open-or-enter)
  nmap <buffer><nowait> <Backspace> <Plug>(fern-my-leave)
  nmap <buffer><nowait> <C-m> <Plug>(fern-my-open-or-enter)
  nmap <buffer><nowait> <C-h> <Plug>(fern-my-leave)
endfunction
```

</details>