### PR TITLE
Improve cd/lcd/tcd action in file scheme

### DIFF
--- a/autoload/fern/scheme/file/mapping/cd.vim
+++ b/autoload/fern/scheme/file/mapping/cd.vim
@@ -1,9 +1,16 @@
 let s:Promise = vital#fern#import('Async.Promise')
 
 function! fern#scheme#file#mapping#cd#init(disable_default_mappings) abort
-  nnoremap <buffer><silent> <Plug>(fern-action-cd)  :<C-u>call <SID>call('cd', 'cd')<CR>
-  nnoremap <buffer><silent> <Plug>(fern-action-lcd) :<C-u>call <SID>call('cd', 'lcd')<CR>
-  nnoremap <buffer><silent> <Plug>(fern-action-tcd) :<C-u>call <SID>call('cd', 'tcd')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-cd:root)  :<C-u>call <SID>call('cd_root', 'cd')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-lcd:root) :<C-u>call <SID>call('cd_root', 'lcd')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-tcd:root) :<C-u>call <SID>call('cd_root', 'tcd')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-cd:cursor)  :<C-u>call <SID>call('cd_cursor', 'cd')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-lcd:cursor) :<C-u>call <SID>call('cd_cursor', 'lcd')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-tcd:cursor) :<C-u>call <SID>call('cd_cursor', 'tcd')<CR>
+
+  nmap <buffer> <Plug>(fern-action-cd) <Plug>(fern-action-cd:cursor)
+  nmap <buffer> <Plug>(fern-action-lcd) <Plug>(fern-action-lcd:cursor)
+  nmap <buffer> <Plug>(fern-action-tcd) <Plug>(fern-action-tcd:cursor)
 endfunction
 
 function! s:call(name, ...) abort
@@ -13,17 +20,24 @@ function! s:call(name, ...) abort
         \)
 endfunction
 
-function! s:map_cd(helper, command) abort
-  let node = a:helper.sync.get_cursor_node()
+function! s:map_cd_root(helper, command) abort
+  return s:cd(a:helper.sync.get_root_node(), a:helper, a:command)
+endfunction
+
+function! s:map_cd_cursor(helper, command) abort
+  return s:cd(a:helper.sync.get_cursor_node(), a:helper, a:command)
+endfunction
+
+function! s:cd(node, helper, command) abort
   if a:command ==# 'tcd' && !exists(':tcd')
     let winid = win_getid()
     silent execute printf(
           \ 'keepalt keepjumps %d,%dwindo lcd %s',
-          \ 1, winnr('$'), fnameescape(node._path),
+          \ 1, winnr('$'), fnameescape(a:node._path),
           \)
     call win_gotoid(winid)
   else
-    execute a:command fnameescape(node._path)
+    execute a:command fnameescape(a:node._path)
   endif
   return s:Promise.resolve()
 endfunction


### PR DESCRIPTION
- Add cd:root/lcd:root/tcd:root action to perform cd/lcd/tcd on root node
- Add cd:cursor/lcd:cursor/tcd:cursor action to perform cd/lcd/tcd on cursor node
- Alias cd/lcd/tcd to cd:cursor/lcd:cursor/tcd:cursor for backward compatibility

This PR partially fix #107 while current `cd/lcd/tcd` action always refer the cursor node.