### PR TITLE
Add <Plug>(fern-wait) to synchronously wait asynchronous action

### DIFF
--- a/autoload/fern/mapping.vim
+++ b/autoload/fern/mapping.vim
@@ -29,5 +29,6 @@ call s:Config.config(expand('<sfile>:p'), {
       \   'node',
       \   'open',
       \   'tree',
+      \   'wait',
       \ ],
       \})

--- a/autoload/fern/mapping/wait.vim
+++ b/autoload/fern/mapping/wait.vim
@@ -1,0 +1,38 @@
+let s:Config = vital#fern#import('Config')
+let s:Promise = vital#fern#import('Async.Promise')
+
+function! fern#mapping#wait#init(disable_default_mappings) abort
+  nnoremap <buffer><silent>
+        \ <Plug>(fern-wait-viewer:ready)
+        \ :<C-u>call <SID>call('hook', 'viewer:ready')<CR>
+  nmap <buffer> <Plug>(fern-wait) <Plug>(fern-wait-viewer:ready)
+endfunction
+
+function! s:call(name, ...) abort
+  return call(
+        \ 'fern#mapping#call',
+        \ [funcref(printf('s:map_%s', a:name))] + a:000,
+        \)
+endfunction
+
+function! s:map_hook(helper, hook) abort
+  let [_, err] = s:Promise.wait(
+        \ fern#hook#promise(a:hook),
+        \ {
+        \   'interval': g:fern#mapping#wait#interval,
+        \   'timeout': g:fern#mapping#wait#timeout,
+        \ },
+        \)
+  if err isnot# v:null
+    throw printf(
+          \ '[fern] Failed to wait hook "%s": %s',
+          \ a:hook,
+          \ err,
+          \)
+  endif
+endfunction
+
+call s:Config.config(expand('<sfile>:p'), {
+      \ 'interval': 100,
+      \ 'timeout': 1000,
+      \})

--- a/doc/fern.txt
+++ b/doc/fern.txt
@@ -169,6 +169,25 @@ hit "e", add the following code:
 	" Use 'open:split' instead of 'open:edit' for 'open' action
 	nmap <buffer> <Plug>(fern-action-open) <Plug>(fern-action-open:split)
 <
+							*fern-custom-wait*
+Fern provide following mapping helper:
+
+	*<Plug>(fern-wait)*	Wait until the fern buffer become ready which
+				would opened just before this mapping. This is
+				required while fern buffers are loaded
+				asynchronously but mappings are inovked
+				synchronously.
+
+For example, following execute "tcd:root" action every after "leave" action.
+>
+	nmap <buffer> <Plug>(fern-my-leave-and-tcd)
+	      \ <Plug>(fern-action-leave)
+	      \ <Plug>(fern-wait)
+	      \ <Plug>(fern-action-tcd:root)
+<
+Without <Plug>(fern-wait), the "tcd:root" action will be invoked before actual
+"leave" while "leave" action is asynchronous.
+
 							*fern-custom-smart*
 Fern provide following mapping helper functions:
 


### PR DESCRIPTION
While #108 is too complicated for users, this is a different approach.

User can wait an asynchronous action by `<Plug>(fern-wait)` thus users can define mappings like

```vim
nmap <buffer> <Plug>(my-fern-enter-or-tcd)
      \ <Plug>(fern-action-enter)
      \ <Plug>(fern-wait)
      \ <Plug>(fern-action-tcd:root)
```