### PR TITLE
Add :FernDo command and deprecate :FernFocus command

### DIFF
--- a/autoload/fern/internal/command/do.vim
+++ b/autoload/fern/internal/command/do.vim
@@ -1,0 +1,47 @@
+function! fern#internal#command#do#command(mods, fargs) abort
+  let winid_saved = win_getid()
+  try
+    let stay = fern#internal#args#pop(a:fargs, 'stay', v:false)
+    let drawer = fern#internal#args#pop(a:fargs, 'drawer', v:false)
+
+    if len(a:fargs) is# 0
+          \ || type(stay) isnot# v:t_bool
+          \ || type(drawer) isnot# v:t_bool
+      throw 'Usage: FernDo {expr...} [-drawer] [-stay]'
+    endif
+
+    " Does all options are handled?
+    call fern#internal#args#throw_if_dirty(a:fargs)
+
+    let found = fern#internal#window#find(
+          \ funcref('s:predicator', [drawer]),
+          \ winnr() + 1,
+          \)
+    if !found
+      return
+    endif
+    call win_gotoid(win_getid(found))
+    execute join([a:mods] + a:fargs, ' ')
+  catch
+    echohl ErrorMsg
+    echo v:exception
+    echohl None
+    call fern#logger#debug(v:exception)
+    call fern#logger#debug(v:throwpoint)
+  finally
+    if stay
+      call win_gotoid(winid_saved)
+    endif
+  endtry
+endfunction
+
+function! fern#internal#command#do#complete(arglead, cmdline, cursorpos) abort
+  return fern#internal#complete#options(a:arglead, a:cmdline, a:cursorpos)
+endfunction
+
+function! s:predicator(drawer, winnr) abort
+  let bufname = bufname(winbufnr(a:winnr))
+  let fri = fern#fri#parse(bufname)
+  return fri.scheme ==# 'fern'
+        \ && (!a:drawer || fri.authority =~# '\<drawer\>')
+endfunction

--- a/autoload/fern/internal/command/fern.vim
+++ b/autoload/fern/internal/command/fern.vim
@@ -1,15 +1,5 @@
 let s:Promise = vital#fern#import('Async.Promise')
 let s:drawer_opener = 'topleft vsplit'
-let s:options = [
-      \ '-drawer',
-      \ '-width=',
-      \ '-keep',
-      \ '-stay',
-      \ '-wait',
-      \ '-reveal=',
-      \ '-toggle',
-      \ '-opener=',
-      \]
 
 function! fern#internal#command#fern#command(mods, fargs) abort
   try

--- a/autoload/fern/internal/command/focus.vim
+++ b/autoload/fern/internal/command/focus.vim
@@ -1,38 +1,15 @@
 function! fern#internal#command#focus#command(mods, fargs) abort
-  try
-    let drawer = fern#internal#args#pop(a:fargs, 'drawer', v:false)
-
-    if len(a:fargs) isnot# 0
-          \ || type(drawer) isnot# v:t_bool
-      throw 'Usage: FernFocus [-drawer]'
-    endif
-
-    " Does all options are handled?
-    call fern#internal#args#throw_if_dirty(a:fargs)
-
-    let found = fern#internal#window#find(
-          \ funcref('s:predicator', [drawer]),
-          \ winnr() + 1,
-          \)
-    if found
-      call win_gotoid(win_getid(found))
-    endif
-  catch
-    echohl ErrorMsg
-    echo v:exception
-    echohl None
-    call fern#logger#debug(v:exception)
-    call fern#logger#debug(v:throwpoint)
-  endtry
+  call fern#util#deprecated(
+        \ '":FernFocus"',
+        \ '":FernDo :"'
+        \)
+  if fern#internal#args#pop(a:fargs, 'drawer', v:false)
+    FernDo : -drawer
+  else
+    FernDo :
+  endif
 endfunction
 
 function! fern#internal#command#focus#complete(arglead, cmdline, cursorpos) abort
   return fern#internal#complete#options(a:arglead, a:cmdline, a:cursorpos)
-endfunction
-
-function! s:predicator(drawer, winnr) abort
-  let bufname = bufname(winbufnr(a:winnr))
-  let fri = fern#fri#parse(bufname)
-  return fri.scheme ==# 'fern'
-        \ && (!a:drawer || fri.authority =~# '\<drawer\>')
 endfunction

--- a/doc/fern.txt
+++ b/doc/fern.txt
@@ -382,8 +382,18 @@ COMMAND							*fern-command*
 	See |:Fern| for other arguments and options. Note that -opener options
 	is ignored for project drawer style.
 
+							*:FernDo*
+:FernDo {expr...} [-drawer] [-stay]
+	Focus a next fern viewer and execute {expr...}. It does nothing if no
+	next fern viewer is found.
+	If "-drawer" option is specified, it focus and execute only a project
+	drawer style fern.
+	If "-stay" option is specified, it stay focus after execution.
+	Note that the command can be followed by a '|' and another command.
+
 							*:FernFocus*
 :FernFocus [-drawer]
+	DEPRECATED: Use |:FernDo| with ":" like ":FernDo :" instead.
 	Focus a next fern viewer. If "-drawer" option is specified, it focus
 	only a project drawer style fern.
 	Note that the command can be followed by a '|' and another command.

--- a/plugin/fern.vim
+++ b/plugin/fern.vim
@@ -13,6 +13,11 @@ command! -bar -nargs=*
       \ FernFocus
       \ call fern#internal#command#focus#command(<q-mods>, [<f-args>])
 
+command! -bar -nargs=*
+      \ -complete=customlist,fern#internal#command#do#complete
+      \ FernDo
+      \ call fern#internal#command#do#command(<q-mods>, [<f-args>])
+
 function! s:BufReadCmd() abort
   if exists('b:fern') && !get(g:, 'fern_debug')
     return


### PR DESCRIPTION
To solve #94, `:FernDo` command has added.

For example, if users want to close fern drawer after `open`action then

```vim
nmap <buffer><silent> <Plug>(fern-my-open-and-close)
      \ <Plug>(fern-action-open)
      \ :<C-u>FernDo close -drawer -stay<CR>
```

In favor of `:FernDo`, the `:FernFocus` command become deprecated. Use `:FernDo :` instead.