### PR TITLE
Use sign instead to display marks and add "badge" support for 3rd parties

### DIFF
--- a/autoload/fern.vim
+++ b/autoload/fern.vim
@@ -30,4 +30,5 @@ call s:Config.config(expand('<sfile>:p'), {
       \ 'comparators': get(g:, 'fern#internal#core#comparators', {}),
       \ 'drawer_width': 30,
       \ 'drawer_keep': v:false,
+      \ 'mark_symbol': '*',
       \})

--- a/autoload/fern/internal/mark.vim
+++ b/autoload/fern/internal/mark.vim
@@ -1,0 +1,29 @@
+function! fern#internal#mark#replace(bufnr, lnums) abort
+  call execute(printf('sign unplace * group=fern-mark buffer=%d', a:bufnr))
+  call map(a:lnums, { _, v -> execute(printf(
+        \ 'sign place %d group=fern-mark line=%d name=FernSignMarked buffer=%d',
+        \ v,
+        \ v,
+        \ a:bufnr,
+        \))})
+endfunction
+
+function! s:define_signs() abort
+  execute printf(
+        \ 'sign define FernSignMarked text=%s linehl=FernMarkedLine texthl=FernMarkedText',
+        \ g:fern#mark_symbol,
+        \)
+endfunction
+
+function! s:define_highlight() abort
+  highlight default link FernMarkedLine Title
+  highlight default link FernMarkedText Title
+endfunction
+
+augroup fern_mark_internal
+  autocmd!
+  autocmd ColorScheme * call s:define_highlight()
+augroup END
+
+call s:define_signs()
+call s:define_highlight()

--- a/autoload/fern/internal/node.vim
+++ b/autoload/fern/internal/node.vim
@@ -207,6 +207,7 @@ endfunction
 function! s:new(node, ...) abort
   let node = extend(a:node, {
         \ 'label': get(a:node, 'label', a:node.name),
+        \ 'badge': get(a:node, 'badge', ''),
         \ 'hidden': get(a:node, 'hidden', 0),
         \ 'bufname': get(a:node, 'bufname', v:null),
         \ 'concealed': get(a:node, 'concealed', {}),

--- a/autoload/fern/internal/spinner.vim
+++ b/autoload/fern/internal/spinner.vim
@@ -25,7 +25,7 @@ function! s:update(timer, spinner, bufnr) abort
     return
   endif
   let frame = a:spinner.next()
-  call execute(printf('sign unplace * group=fern buffer=%d', a:bufnr))
+  call execute(printf('sign unplace * group=fern-spinner buffer=%d', a:bufnr))
   let info = getwininfo(winid)[0]
   let rng = sort([info.topline, info.botline], 'n')
   for lnum in range(rng[0], rng[1])
@@ -36,7 +36,7 @@ function! s:update(timer, spinner, bufnr) abort
       continue
     endif
     call execute(printf(
-          \ 'sign place %d group=fern line=%d name=%s buffer=%d',
+          \ 'sign place %d group=fern-spinner line=%d name=%s buffer=%d',
           \ lnum,
           \ lnum,
           \ frame,

--- a/autoload/fern/internal/viewer.vim
+++ b/autoload/fern/internal/viewer.vim
@@ -67,10 +67,12 @@ function! s:init() abort
     call fern#internal#drawer#init()
     call fern#internal#spinner#start()
     call helper.fern.renderer.highlight()
+    call fern#hook#emit('renderer:highlight', helper)
 
     " now the buffer is ready so set filetype to emit FileType
     setlocal filetype=fern
     call helper.fern.renderer.syntax()
+    call fern#hook#emit('renderer:syntax', helper)
     call fern#internal#action#init()
 
     let reveal = split(fri.fragment, '/')

--- a/autoload/fern/internal/viewer.vim
+++ b/autoload/fern/internal/viewer.vim
@@ -67,12 +67,18 @@ function! s:init() abort
     call fern#internal#drawer#init()
     call fern#internal#spinner#start()
     call helper.fern.renderer.highlight()
+    " Notify plugins
     call fern#hook#emit('renderer:highlight', helper)
+    " Notify users
+    doautocmd <nomodeline> User FernHighlight
 
     " now the buffer is ready so set filetype to emit FileType
     setlocal filetype=fern
     call helper.fern.renderer.syntax()
+    " Notify plugins
     call fern#hook#emit('renderer:syntax', helper)
+    " Notify users
+    doautocmd <nomodeline> User FernSyntax
     call fern#internal#action#init()
 
     let reveal = split(fri.fragment, '/')
@@ -108,7 +114,10 @@ function! s:BufReadCmd() abort
   let helper = fern#helper#new()
   setlocal filetype=fern
   call helper.fern.renderer.syntax()
+  " Notify plugins
   call fern#hook#emit('renderer:syntax', helper)
+  " Notify users
+  doautocmd <nomodeline> User FernSyntax
   let root = helper.sync.get_root_node()
   let cursor = get(b:, 'fern_cursor', getcurpos())
   call s:Promise.resolve()
@@ -123,5 +132,14 @@ endfunction
 function! s:ColorScheme() abort
   let helper = fern#helper#new()
   call helper.fern.renderer.highlight()
+  " Notify plugins
   call fern#hook#emit('renderer:highlight', helper)
+  " Notify users
+  doautocmd <nomodeline> User FernHighlight
 endfunction
+
+augroup fern-internal-viewer-internal
+  autocmd!
+  autocmd User FernSyntax :
+  autocmd User FernHighlight :
+augroup END

--- a/autoload/fern/mapping/mark.vim
+++ b/autoload/fern/mapping/mark.vim
@@ -30,7 +30,7 @@ function! s:map_mark_set(helper) abort
     return s:Promise.reject('no node found on a cursor line')
   endif
   return a:helper.async.set_mark(node.__key, 1)
-        \.then({ -> a:helper.async.redraw() })
+        \.then({ -> a:helper.async.remark() })
 endfunction
 
 function! s:map_mark_unset(helper) abort
@@ -39,7 +39,7 @@ function! s:map_mark_unset(helper) abort
     return s:Promise.reject('no node found on a cursor line')
   endif
   return a:helper.async.set_mark(node.__key, 0)
-        \.then({ -> a:helper.async.redraw() })
+        \.then({ -> a:helper.async.remark() })
 endfunction
 
 function! s:map_mark_toggle(helper) abort
@@ -55,5 +55,6 @@ function! s:map_mark_toggle(helper) abort
 endfunction
 
 function! s:map_mark_clear(helper) abort
-  return a:helper.update_marks([])
+  return a:helper.async.update_marks([])
+        \.then({ -> a:helper.async.remark() })
 endfunction

--- a/autoload/fern/mapping/open.vim
+++ b/autoload/fern/mapping/open.vim
@@ -82,7 +82,7 @@ function! s:map_open(helper, opener) abort
     noautocmd call win_gotoid(winid)
     noautocmd call win_gotoid(winid_fern)
     return a:helper.async.update_marks([])
-        \.then({ -> a:helper.async.redraw() })
+        \.then({ -> a:helper.async.remark() })
   catch
     return s:Promise.reject(v:exception)
   endtry

--- a/autoload/fern/renderer/default.vim
+++ b/autoload/fern/renderer/default.vim
@@ -51,9 +51,10 @@ function! s:syntax() abort
         \ escape(g:fern#renderer#default#collapsed_symbol, s:ESCAPE_PATTERN),
         \ escape(g:fern#renderer#default#expanded_symbol, s:ESCAPE_PATTERN),
         \)
-  syntax match FernRootText   /.*$/ contained
-  syntax match FernLeafText   /.*$/ contained
-  syntax match FernBranchText /.*$/ contained
+  syntax match FernRootText   /.*\ze .*$/ contained nextgroup=FernBadge
+  syntax match FernLeafText   /.*\ze .*$/ contained nextgroup=FernBadge
+  syntax match FernBranchText /.*\ze .*$/ contained nextgroup=FernBadge
+  syntax match FernBadge      /.*/        contained
 endfunction
 
 function! s:highlight() abort
@@ -68,7 +69,7 @@ endfunction
 function! s:render_node(node, base, options) abort
   let level = len(a:node.__key) - a:base
   if level is# 0
-    return prefix . a:options.root_symbol . a:node.label
+    return a:options.root_symbol . a:node.label . ' ' . a:node.badge
   endif
   let leading = repeat(a:options.leading, level - 1)
   let symbol = a:node.status is# s:STATUS_NONE
@@ -76,7 +77,7 @@ function! s:render_node(node, base, options) abort
         \ : a:node.status is# s:STATUS_COLLAPSED
         \   ? a:options.collapsed_symbol
         \   : a:options.expanded_symbol
-  return prefix . leading . symbol . a:node.label
+  return leading . symbol . a:node.label . ' ' . a:node.badge
 endfunction
 
 call s:Config.config(expand('<sfile>:p'), {

--- a/autoload/fern/renderer/default.vim
+++ b/autoload/fern/renderer/default.vim
@@ -38,7 +38,6 @@ function! s:lnum(index) abort
 endfunction
 
 function! s:syntax() abort
-  syntax clear
   execute printf(
         \ 'syntax match FernRootSymbol /\%%1l%s/ nextgroup=FernRootText',
         \ escape(g:fern#renderer#default#root_symbol, s:ESCAPE_PATTERN),

--- a/autoload/fern/renderer/default.vim
+++ b/autoload/fern/renderer/default.vim
@@ -1,7 +1,7 @@
 let s:Config = vital#fern#import('Config')
 let s:AsyncLambda = vital#fern#import('Async.Lambda')
 
-let s:PATTERN = '^$~.*[]\'
+let s:ESCAPE_PATTERN = '^$~.*[]\'
 let s:STATUS_NONE = g:fern#STATUS_NONE
 let s:STATUS_COLLAPSED = g:fern#STATUS_COLLAPSED
 
@@ -15,19 +15,17 @@ function! fern#renderer#default#new() abort
         \}
 endfunction
 
-function! s:render(nodes, marks) abort
+function! s:render(nodes) abort
   let options = {
         \ 'leading': g:fern#renderer#default#leading,
         \ 'root_symbol': g:fern#renderer#default#root_symbol,
         \ 'leaf_symbol': g:fern#renderer#default#leaf_symbol,
         \ 'expanded_symbol': g:fern#renderer#default#expanded_symbol,
         \ 'collapsed_symbol': g:fern#renderer#default#collapsed_symbol,
-        \ 'marked_symbol': g:fern#renderer#default#marked_symbol,
-        \ 'unmarked_symbol': g:fern#renderer#default#unmarked_symbol,
         \}
   let base = len(a:nodes[0].__key)
   let Profile = fern#profile#start('fern#renderer#default#s:render')
-  return s:AsyncLambda.map(copy(a:nodes), { v, -> s:render_node(v, a:marks, base, options) })
+  return s:AsyncLambda.map(copy(a:nodes), { v, -> s:render_node(v, base, options) })
         \.finally({ -> Profile() })
 endfunction
 
@@ -42,32 +40,33 @@ endfunction
 function! s:syntax() abort
   syntax clear
   execute printf(
-        \ 'syntax match FernLeaf /^\s*%s/',
-        \ escape(g:fern#renderer#default#leaf_symbol, s:PATTERN),
+        \ 'syntax match FernRootSymbol /\%%1l%s/ nextgroup=FernRootText',
+        \ escape(g:fern#renderer#default#root_symbol, s:ESCAPE_PATTERN),
         \)
   execute printf(
-        \ 'syntax match FernBranch /^\s*\%%(%s\|%s\).*/',
-        \ escape(g:fern#renderer#default#collapsed_symbol, s:PATTERN),
-        \ escape(g:fern#renderer#default#expanded_symbol, s:PATTERN),
+        \ 'syntax match FernLeafSymbol /^\s*%s/ nextgroup=FernLeafText',
+        \ escape(g:fern#renderer#default#leaf_symbol, s:ESCAPE_PATTERN),
         \)
-  syntax match FernRoot /\%1l.*/
   execute printf(
-        \ 'syntax match FernMarked /^%s.*/',
-        \ escape(g:fern#renderer#default#marked_symbol, s:PATTERN),
+        \ 'syntax match FernBranchSymbol /^\s*\%%(%s\|%s\)/ nextgroup=FernBranchText',
+        \ escape(g:fern#renderer#default#collapsed_symbol, s:ESCAPE_PATTERN),
+        \ escape(g:fern#renderer#default#expanded_symbol, s:ESCAPE_PATTERN),
         \)
+  syntax match FernRootText   /.*$/ contained
+  syntax match FernLeafText   /.*$/ contained
+  syntax match FernBranchText /.*$/ contained
 endfunction
 
 function! s:highlight() abort
-  highlight default link FernRoot   Directory
-  highlight default link FernLeaf   Directory
-  highlight default link FernBranch Directory
-  highlight default link FernMarked Title
+  highlight default link FernRootSymbol   Directory
+  highlight default link FernRootText     Directory
+  highlight default link FernLeafSymbol   Directory
+  highlight default link FernLeafText     None
+  highlight default link FernBranchSymbol Directory
+  highlight default link FernBranchText   Directory
 endfunction
 
-function! s:render_node(node, marks, base, options) abort
-  let prefix = index(a:marks, a:node.__key) is# -1
-        \ ? a:options.unmarked_symbol
-        \ : a:options.marked_symbol
+function! s:render_node(node, base, options) abort
   let level = len(a:node.__key) - a:base
   if level is# 0
     return prefix . a:options.root_symbol . a:node.label
@@ -87,6 +86,15 @@ call s:Config.config(expand('<sfile>:p'), {
       \ 'leaf_symbol': '|  ',
       \ 'collapsed_symbol': '|+ ',
       \ 'expanded_symbol': '|- ',
-      \ 'marked_symbol': '* ',
-      \ 'unmarked_symbol': '  ',
       \})
+
+" Obsolete warnings
+if exists('g:fern#renderer#default#marked_symbol')
+  call fern#util#obsolete(
+        \ 'g:fern#renderer#default#marked_symbol',
+        \ 'g:fern#mark_symbol',
+        \)
+endif
+if exists('g:fern#renderer#default#unmarked_symbol')
+  call fern#util#obsolete('g:fern#renderer#default#unmarked_symbol')
+endif

--- a/autoload/fern/scheme/dict/mapping/clipboard.vim
+++ b/autoload/fern/scheme/dict/mapping/clipboard.vim
@@ -34,7 +34,7 @@ function! s:map_clipboard_move(helper) abort
         \}
   return s:Promise.resolve()
         \.then({ -> a:helper.async.update_marks([]) })
-        \.then({ -> a:helper.async.redraw() })
+        \.then({ -> a:helper.async.remark() })
         \.then({ -> a:helper.sync.echo(printf('%d items are saved in clipboard to move', len(nodes))) })
 endfunction
 
@@ -46,7 +46,7 @@ function! s:map_clipboard_copy(helper) abort
         \}
   return s:Promise.resolve()
         \.then({ -> a:helper.async.update_marks([]) })
-        \.then({ -> a:helper.async.redraw() })
+        \.then({ -> a:helper.async.remark() })
         \.then({ -> a:helper.sync.echo(printf('%d items are saved in clipboard to copy', len(nodes))) })
 endfunction
 

--- a/autoload/fern/scheme/file/mapping/clipboard.vim
+++ b/autoload/fern/scheme/file/mapping/clipboard.vim
@@ -34,7 +34,7 @@ function! s:map_clipboard_move(helper) abort
         \}
   return s:Promise.resolve()
         \.then({ -> a:helper.async.update_marks([]) })
-        \.then({ -> a:helper.async.redraw() })
+        \.then({ -> a:helper.async.remark() })
         \.then({ -> a:helper.sync.echo(printf('%d items are saved in clipboard to move', len(nodes))) })
 endfunction
 
@@ -46,7 +46,7 @@ function! s:map_clipboard_copy(helper) abort
         \}
   return s:Promise.resolve()
         \.then({ -> a:helper.async.update_marks([]) })
-        \.then({ -> a:helper.async.redraw() })
+        \.then({ -> a:helper.async.remark() })
         \.then({ -> a:helper.sync.echo(printf('%d items are saved in clipboard to copy', len(nodes))) })
 endfunction
 

--- a/autoload/fern/scheme/file/mapping/terminal.vim
+++ b/autoload/fern/scheme/file/mapping/terminal.vim
@@ -53,7 +53,7 @@ function! s:map_terminal(helper, opener) abort
       enew | call s:term(node._path)
     endfor
     return a:helper.async.update_marks([])
-        \.then({ -> a:helper.async.redraw() })
+        \.then({ -> a:helper.async.remark() })
   catch
     return s:Promise.reject(v:exception)
   endtry

--- a/doc/fern-develop.txt
+++ b/doc/fern-develop.txt
@@ -110,6 +110,9 @@ A node instance is a tree item which has the following attributes:
 
 "label"		A |String| used to display the node in a tree view.
 
+"badge"		A |String| used to display the node badge in a tree view.
+		Only first character is used in the default renderer.
+
 "hidden"	A 1/0 to indicate if the node should be hidden. All hidden
 		nodes become visible once fern enter hidden mode.
 

--- a/doc/fern-develop.txt
+++ b/doc/fern-develop.txt
@@ -192,8 +192,11 @@ Renderer is an instance which has the following methods to render a list of
 nodes as a tree.
 
 					*fern-develop-renderer.render()*
-.render({nodes}, {marks})
+.render({nodes})
 	Return a promise which is resolved to a list of |String|.
+
+	Change (v1.6.0):~
+	Second argumet ({marks}) has removed.
 
 					*fern-develop-renderer.index()*
 .index({lnum})

--- a/doc/fern-develop.txt
+++ b/doc/fern-develop.txt
@@ -438,6 +438,10 @@ Following methods are executed asynchronously and return a promise.
 .async.redraw()
 	Return a promise to redraw the content.
 
+			*fern-develop-helper.async.remark()*
+.async.remark()
+	Return a promise to remark the content.
+
 			*fern-develop-helper.async.set_mark()*
 .async.set_mark({key}, {value})
 	Return a promise to set mark to a node identified by the {key}.
@@ -517,6 +521,10 @@ Following hook will be emitted by |fern#hook#emit()| from fern itself.
 
 "viewer:redraw" ({helper})
 	Called when fern viewer has redrawed.
+	The {helper} is a helper instance described in |fern-develop-helper|.
+
+"viewer:remark" ({helper})
+	Called when fern viewer has remarked.
 	The {helper} is a helper instance described in |fern-develop-helper|.
 
 "viewer:ready" ({helper})

--- a/doc/fern.txt
+++ b/doc/fern.txt
@@ -227,20 +227,20 @@ RENDERER						*fern-renderer*
 
 Renderer is an object to render nodes as a tree like (default renderer):
 >
-	  fern.vim
-	* |- autoload
-	   |+ fern
-	   |+ vital
-	*  |  fern.vim
-	* |- doc
-	   |  fern-develop.txt
-	   |  fern.txt
-	   |  tags
-	  |+ ftplugin
-	  |+ plugin
-	  |+ test
-	  |  LICENSE
-	  |  README.md
+	fern.vim
+	|- autoload
+	 |+ fern
+	 |+ vital
+	 |  fern.vim
+	|- doc
+	 |  fern-develop.txt
+	 |  fern.txt
+	 |  tags
+	|+ ftplugin
+	|+ plugin
+	|+ test
+	|  LICENSE
+	|  README.md
 <
 Users can customize above appearance by the following variables.
 
@@ -265,12 +265,12 @@ Users can customize above appearance by the following variables.
 	Default: "|- "
 
 *g:fern#renderer#default#marked_symbol*
-	A |String| used as a symbol of mark.
-	Default: "* "
+	OBSOLETE(v1.6.0)~
+	Use |g:fern#mark_symbol| instead.
 
 *g:fern#renderer#default#unmarked_symbol*
-	A |String| used as a symbol of unmark.
-	Default: "  "
+	OBSOLETE(v1.6.0)~
+	No alternative feature is provided.
 
 Or create user custom renderer to change the appearance completely.
 See |fern-develop-renderer| for more details.
@@ -414,6 +414,11 @@ VARIABLE						*fern-variable*
 	A |Boolean| which indicate wheter the last fern window should be keep
 	open or close.
 	Default: |v:false|
+
+*g:fern#mark_symbol*
+	A |String| which is used as a mark symbol text.
+	Note that users must restart Vim to apply changes.
+	Default: "*"
 
 -----------------------------------------------------------------------------
 COMMAND							*fern-command*

--- a/doc/fern.txt
+++ b/doc/fern.txt
@@ -17,6 +17,8 @@ INTERFACE				|fern-interface|
   VARIABLE				|fern-variable|
   COMMAND				|fern-command|
   FUNCTION				|fern-function|
+  AUTOCMD				|fern-autocmd|
+  HIGHLIGHT				|fern-highlight|
 CHANGELOG				|fern-changelog|
 
 
@@ -271,6 +273,8 @@ Users can customize above appearance by the following variables.
 *g:fern#renderer#default#unmarked_symbol*
 	OBSOLETE(v1.6.0)~
 	No alternative feature is provided.
+
+See |FernHighlight| and |fern-highlight| to change pre-defeined |highlight|.
 
 Or create user custom renderer to change the appearance completely.
 See |fern-develop-renderer| for more details.
@@ -548,7 +552,74 @@ fern#smart#scheme({default}, {schemes})
 	      \     'bookmark': "\<C-^>",
 	      \   },
 	      \ )
+
+-----------------------------------------------------------------------------
+AUTOCMD							*fern-autocmd*
+
+						*FernHighlight*
+FernHighlight
+	Invoked after a fern renderer and 3rd party plugins defined highlight.
+	Use this autocmd to overwrite existing |highlight| like:
+>
+	function! s:on_highlight() abort
+	  " Use brighter highlight on root node
+	  highlight link FernRootSymbol Title
+	  highlight link FernRootText   Title
+	endfunction
+
+	augroup my-fern-highlight
+	  autocmd!
+	  autocmd User FernHighlight call s:on_highlight()
+	augroup END
 <
+	See |fern-highlight| for pre-defined |highlight|.
+
+						*FernSyntax*
+FernSyntax
+	Invoked after a fern renderer and 3rd party plugins defined syntax.
+	Use this |autocmd| to overwrite existing |syntax|.
+	Note that if you'd like to change color/highlight, use |FernHighlight|
+	autocmd instead. This autocmd exists for more complex (heavy) use.
+
+-----------------------------------------------------------------------------
+HIGHLIGHT						*fern-highlight*
+
+FernMarkedLine					*hl-FernMarkedLine*
+	A |highlight| group used as a line highlight of mark |sign|.
+
+FernMarkedText					*hl-FernMarkedText*
+	A |highlight| group used as a text highlight of mark |sign|.
+
+FernRootSymbol					*hl-FernRootSymbol*
+	A |highlight| group of renderer used for root node symbol.
+	An actual appearance will be determined by the |fern-renderer| thus 
+	this highlight might not be referred.
+	
+FernRootText					*hl-FernRootText*
+	A |highlight| group of renderer used for root node text.
+	An actual appearance will be determined by the |fern-renderer| thus 
+	this highlight might not be referred.
+
+FernLeafSymbol					*hl-FernLeafSymbol*
+	A |highlight| group of renderer used for leaf node symbol.
+	An actual appearance will be determined by the |fern-renderer| thus 
+	this highlight might not be referred.
+	
+FernLeafText					*hl-FernLeafText*
+	A |highlight| group of renderer used for leaf node text.
+	An actual appearance will be determined by the |fern-renderer| thus 
+	this highlight might not be referred.
+
+FernBranchSymbol				*hl-FernBranchSymbol*
+	A |highlight| group of renderer used for branch node symbol.
+	An actual appearance will be determined by the |fern-renderer| thus 
+	this highlight might not be referred.
+	
+FernBranchText				*hl-FernBranchText*
+	A |highlight| group of renderer used for branch node text.
+	An actual appearance will be determined by the |fern-renderer| thus 
+	this highlight might not be referred.
+
 
 =============================================================================
 CHANGELOG						*fern-changelog*

--- a/test/behavior/Fern.vimspec
+++ b/test/behavior/Fern.vimspec
@@ -25,38 +25,38 @@ Describe Fern
       Fern debug:/// -wait
       Assert Equals(winnr('$'), 1)
       Assert Equals(getline(1, '$'), [
-            \ '  root',
-            \ '  |+ deep',
-            \ '  |+ heavy',
-            \ '  |+ shallow',
-            \ '  |  leaf',
+            \ 'root ',
+            \ '|+ deep ',
+            \ '|+ heavy ',
+            \ '|+ shallow ',
+            \ '|  leaf ',
             \])
     End
 
     It Fern debug:/// -reveal=deep/alpha/beta reveals to 'deep/alpha/beta'
       Fern debug:/// -reveal=deep/alpha/beta -wait
       Assert Equals(getline(1, '$'), [
-            \ '  root',
-            \ '  |- deep',
-            \ '   |- alpha',
-            \ '    |- beta',
-            \ '     |  gamma',
-            \ '  |+ heavy',
-            \ '  |+ shallow',
-            \ '  |  leaf',
+            \ 'root ',
+            \ '|- deep ',
+            \ ' |- alpha ',
+            \ '  |- beta ',
+            \ '   |  gamma ',
+            \ '|+ heavy ',
+            \ '|+ shallow ',
+            \ '|  leaf ',
             \])
     End
 
     It Fern debug:/// -reveal=deep/alpha/zeta reveals to 'deep/alpha'
       Fern debug:/// -reveal=deep/alpha/zeta -wait
       Assert Equals(getline(1, '$'), [
-            \ '  root',
-            \ '  |- deep',
-            \ '   |- alpha',
-            \ '    |+ beta',
-            \ '  |+ heavy',
-            \ '  |+ shallow',
-            \ '  |  leaf',
+            \ 'root ',
+            \ '|- deep ',
+            \ ' |- alpha ',
+            \ '  |+ beta ',
+            \ '|+ heavy ',
+            \ '|+ shallow ',
+            \ '|  leaf ',
             \])
     End
   End
@@ -66,9 +66,9 @@ Describe Fern
       execute printf('Fern %s -wait', fnameescape(workdir))
       Assert Equals(winnr('$'), 1)
       Assert Equals(getline(2, '$'), [
-            \ '  |+ deep',
-            \ '  |+ shallow',
-            \ '  |  leaf',
+            \ '|+ deep ',
+            \ '|+ shallow ',
+            \ '|  leaf ',
             \])
     End
 
@@ -76,12 +76,12 @@ Describe Fern
       execute printf('Fern %s -reveal=deep/alpha/beta -wait', fnameescape(workdir))
       Assert Equals(winnr('$'), 1)
       Assert Equals(getline(2, '$'), [
-            \ '  |- deep',
-            \ '   |- alpha',
-            \ '    |- beta',
-            \ '     |  gamma',
-            \ '  |+ shallow',
-            \ '  |  leaf',
+            \ '|- deep ',
+            \ ' |- alpha ',
+            \ '  |- beta ',
+            \ '   |  gamma ',
+            \ '|+ shallow ',
+            \ '|  leaf ',
             \])
     End
 
@@ -93,12 +93,12 @@ Describe Fern
             \)
       Assert Equals(winnr('$'), 1)
       Assert Equals(getline(2, '$'), [
-            \ '  |- deep',
-            \ '   |- alpha',
-            \ '    |- beta',
-            \ '     |  gamma',
-            \ '  |+ shallow',
-            \ '  |  leaf',
+            \ '|- deep ',
+            \ ' |- alpha ',
+            \ '  |- beta ',
+            \ '   |  gamma ',
+            \ '|+ shallow ',
+            \ '|  leaf ',
             \])
     End
 
@@ -110,12 +110,12 @@ Describe Fern
             \)
       Assert Equals(winnr('$'), 1)
       Assert Equals(getline(2, '$'), [
-            \ '  |- deep',
-            \ '   |- alpha',
-            \ '    |- beta',
-            \ '     |  gamma',
-            \ '  |+ shallow',
-            \ '  |  leaf',
+            \ '|- deep ',
+            \ ' |- alpha ',
+            \ '  |- beta ',
+            \ '   |  gamma ',
+            \ '|+ shallow ',
+            \ '|  leaf ',
             \])
     End
   End

--- a/test/fern/helper.vimspec
+++ b/test/fern/helper.vimspec
@@ -37,6 +37,7 @@ Describe fern#helper
     let async_methods = [
           \ 'sleep',
           \ 'redraw',
+          \ 'remark',
           \ 'set_mark',
           \ 'set_hidden',
           \ 'set_include',

--- a/test/fern/renderer/default.vimspec
+++ b/test/fern/renderer/default.vimspec
@@ -28,22 +28,22 @@ Describe fern#renderer#default
       End
 
       It returns a promise
-        let p = renderer.render(nodes, [])
+        let p = renderer.render(nodes)
         Assert True(Promise.is_promise(p))
       End
 
       It resolves to a string list for a buffer content
         let [r, e] = Promise.wait(
-              \ renderer.render(nodes, []),
+              \ renderer.render(nodes),
               \ { 'timeout': TIMEOUT },
               \)
         Assert Equals(e, v:null)
         Assert Equals(r, [
-              \ '  root',
-              \ '  |- shallow',
-              \ '   |+ alpha',
-              \ '   |+ beta',
-              \ '   |  gamma',
+              \ 'root ',
+              \ '|- shallow ',
+              \ ' |+ alpha ',
+              \ ' |+ beta ',
+              \ ' |  gamma ',
               \])
       End
 
@@ -53,16 +53,16 @@ Describe fern#renderer#default
               \ ['shallow', 'gamma'],
               \]
         let [r, e] = Promise.wait(
-              \ renderer.render(nodes, marks),
+              \ renderer.render(nodes),
               \ { 'timeout': TIMEOUT },
               \)
         Assert Equals(e, v:null)
         Assert Equals(r, [
-              \ '  root',
-              \ '  |- shallow',
-              \ '*  |+ alpha',
-              \ '   |+ beta',
-              \ '*  |  gamma',
+              \ 'root ',
+              \ '|- shallow ',
+              \ ' |+ alpha ',
+              \ ' |+ beta ',
+              \ ' |  gamma ',
               \])
       End
     End


### PR DESCRIPTION
![tmux 2020-08-01 23-12-58](https://user-images.githubusercontent.com/546312/89103455-06361780-d44d-11ea-85ff-63782061f591.png)

*fern with git status integration (under development)*

To support 3rd party integration like Git status, the following changes had applied

- Use signs to indicate marked nodes
- Add "badge" attribute on nodes to indicate the node status
- Misc.

**This PR will break the existing 3rd party renderer**. See https://github.com/lambdalisue/fern-renderer-nerdfont.vim/pull/2 if you'd like to support a new fern on your custom renderer.