### PR TITLE
Fix ambigious cursor position on Vim

### DIFF
--- a/autoload/fern/helper/sync.vim
+++ b/autoload/fern/helper/sync.vim
@@ -81,6 +81,7 @@ function! s:sync_set_cursor(cursor) abort dict
   let helper = self.helper
   let fern = helper.fern
   call s:WindowCursor.set_cursor(helper.winid, a:cursor)
+  call setbufvar(helper.bufnr, 'fern_cursor', a:cursor)
 endfunction
 let s:sync.set_cursor = funcref('s:sync_set_cursor')
 

--- a/autoload/fern/internal/viewer.vim
+++ b/autoload/fern/internal/viewer.vim
@@ -30,11 +30,11 @@ function! s:init() abort
   setlocal signcolumn=yes
 
   augroup fern_viewer_internal
-    autocmd! * <buffer>
+    autocmd!
     autocmd BufEnter <buffer> setlocal nobuflisted
     autocmd BufReadCmd <buffer> ++nested call s:BufReadCmd()
     autocmd ColorScheme <buffer> call s:ColorScheme()
-    autocmd CursorMoved,CursorMovedI <buffer> let b:fern_cursor = getcurpos()
+    autocmd CursorMoved,CursorMovedI,BufLeave <buffer> let b:fern_cursor = getcurpos()[1:2]
   augroup END
 
   " Add unique fragment to make each buffer uniq
@@ -119,10 +119,10 @@ function! s:BufReadCmd() abort
   " Notify users
   doautocmd <nomodeline> User FernSyntax
   let root = helper.sync.get_root_node()
-  let cursor = get(b:, 'fern_cursor', getcurpos())
+  let cursor = get(b:, 'fern_cursor', getcurpos()[1:2])
   call s:Promise.resolve()
         \.then({ -> helper.async.redraw() })
-        \.then({ -> helper.sync.set_cursor(cursor[1:2]) })
+        \.then({ -> helper.sync.set_cursor(cursor) })
         \.then({ -> helper.async.reload_node(root.__key) })
         \.then({ -> helper.async.redraw() })
         \.then({ -> fern#hook#emit('viewer:ready', helper) })


### PR DESCRIPTION
Close #136

![Kapture 2020-08-03 at 22 40 13](https://user-images.githubusercontent.com/546312/89188974-51c9fc00-d5da-11ea-9f36-dbd9dc6adc6b.gif)

**Note that** fern does NOT re-apply `-reveal` on the existing buffer but fern **restore** the previous cursor position.
The above behavior had broken in Vim if users did not move cursor thus this PR correct the behavior in Vim.

1. `:e README.md`
2. `:Fern . -drawer -toggle -reveal=%` - The cursor is on `README.md`
3. `:q`
4. `:Fern . -drawer -toggle -reveal=%` - The cursor is on `README.md` again
5. Move cursor on `doc` and expand - The cursor is on `fern-develop.txt`
6. `:q`
7. `:Fern . -drawer -toggle -reveal=%` - The cursor is on `fern-develop.txt` rather than `README.md` even `-reveal` points `README.md`