### PR TITLE
Support complex renaming via 'rename' action of 'file' or 'dict' scheme

### DIFF
--- a/autoload/fern/internal/rename_solver.vim
+++ b/autoload/fern/internal/rename_solver.vim
@@ -1,0 +1,107 @@
+let s:ESCAPE_PATTERN = '^$~.*[]\'
+
+function! fern#internal#rename_solver#solve(pairs, ...) abort
+  let options = extend({
+        \ 'exist': { p -> getftype(p) !=# '' },
+        \ 'tempname': { _ -> tempname() },
+        \ 'isdirectory': { p -> isdirectory(p) },
+        \}, a:0 ? a:1 : {},
+        \)
+  let Exist = options.exist
+  let Tempname = options.tempname
+  let IsDirectory = options.isdirectory
+  " Sort by 'dst' depth
+  let pairs = sort(copy(a:pairs), funcref('s:compare'))
+  " Build steps from given pairs
+  let steps = []
+  let tears = []
+  let src_map = s:dict(map(
+        \ copy(a:pairs),
+        \ { -> [v:val[0], 1] },
+        \))
+  for [src, dst] in pairs
+    let rsrc_map = s:dict(map(
+          \ copy(a:pairs),
+          \ { -> [s:replace(v:val[0], steps), 1] },
+          \))
+    let rsrc = s:replace(src, steps)
+    if rsrc ==# dst
+      continue
+    endif
+    let rdst = s:replace_backword(dst, steps)
+    if get(rsrc_map, dst)
+      let tmp = Tempname(dst)
+      call add(steps, [rsrc, tmp, '', ''])
+      call add(tears, [tmp, dst, src, rdst])
+    elseif !get(src_map, rdst) && Exist(rdst)
+      throw printf('Destination "%s" already exist as "%s"', dst, rdst)
+    else
+      call add(steps, [rsrc, dst, src, rdst])
+    endif
+  endfor
+  let steps += tears
+  " Check 'dst' uniqueness
+  let dup = s:find_duplication(map(copy(steps), { -> v:val[1] }))
+  if !empty(dup)
+    throw printf('Destination "%s" appears more than once', dup)
+  endif
+  " Check parent directories of 'dst'
+  for [rsrc, dst, src, rdst] in steps
+    let prv = rdst
+    let cur = fern#internal#path#dirname(prv)
+    while cur !=# '' && cur !=# prv
+      if !Exist(cur)
+        break
+      elseif !IsDirectory(cur)
+        throw printf(
+              \ 'Destination "%s" in "%s" is not directory',
+              \ s:replace(cur, steps),
+              \ dst,
+              \)
+      endif
+      let prv = cur
+      let cur = fern#internal#path#dirname(cur)
+    endwhile
+  endfor
+  return map(steps, { -> v:val[0:1] })
+endfunction
+
+function! s:dict(entries) abort
+  let m = {}
+  call map(copy(a:entries), { _, v -> extend(m, { v[0]: v[1] }) })
+  return m
+endfunction
+
+function! s:compare(a, b) abort
+  let a = len(split(a:a[1], '[/\\]'))
+  let b = len(split(a:b[1], '[/\\]'))
+  return a is# b ? 0 : a > b ? 1 : -1
+endfunction
+
+function! s:find_duplication(list) abort
+  let seen = {}
+  for item in a:list
+    if has_key(seen, item)
+      return item
+    endif
+    let seen[item] = 1
+  endfor
+endfunction
+
+function! s:replace(text, applied) abort
+  let text = a:text
+  for item in a:applied
+    let [src, dst] = item[0:1]
+    let text = substitute(text, escape(src, s:ESCAPE_PATTERN), dst, '')
+  endfor
+  return text
+endfunction
+
+function! s:replace_backword(text, applied) abort
+  let text = a:text
+  for item in reverse(copy(a:applied))
+    let [src, dst] = item[0:1]
+    let text = substitute(text, escape(dst, s:ESCAPE_PATTERN), src, '')
+  endfor
+  return text
+endfunction

--- a/autoload/fern/scheme/dict/mapping/rename.vim
+++ b/autoload/fern/scheme/dict/mapping/rename.vim
@@ -45,7 +45,7 @@ function! s:map_rename(helper, opener) abort
         \ 'is_drawer': a:helper.sync.is_drawer(),
         \}
   let ns = {}
-  return fern#internal#renamer#rename(Factory, options)
+  return fern#internal#replacer#start(Factory, options)
         \.then({ r -> s:_map_rename(a:helper, r) })
         \.then({ n -> s:Lambda.let(ns, 'n', n) })
         \.then({ -> a:helper.async.collapse_modified_nodes(nodes) })

--- a/autoload/fern/scheme/dict/tree.vim
+++ b/autoload/fern/scheme/dict/tree.vim
@@ -99,6 +99,17 @@ function! fern#scheme#dict#tree#move(tree, src, dst) abort
   call fern#scheme#dict#tree#remove(a:tree, a:src)
 endfunction
 
+function! fern#scheme#dict#tree#tempname(tree) abort
+  let value = 0
+  while 1
+    let value += 1
+    let path = '@temp:' . sha256(value)
+    if !fern#scheme#dict#tree#exists(a:tree, path)
+      return path
+    endif
+  endwhile
+endfunction
+
 function! s:select_overwrite_method(path) abort
   let prompt = join([
         \ printf(

--- a/autoload/fern/scheme/file/mapping/rename.vim
+++ b/autoload/fern/scheme/file/mapping/rename.vim
@@ -43,6 +43,9 @@ function! s:map_rename(helper, opener) abort
         \ 'opener': a:opener,
         \ 'cursor': [1, len(root._path) + 1],
         \ 'is_drawer': a:helper.sync.is_drawer(),
+        \ 'modifiers':[
+        \   { r -> fern#internal#rename_solver#solve(r) },
+        \ ],
         \}
   let ns = {}
   return fern#internal#replacer#start(Factory, options)
@@ -56,17 +59,11 @@ endfunction
 
 function! s:_map_rename(helper, result) abort
   let token = a:helper.fern.source.token
-  let ps = []
+  let fs = []
   for [src, dst] in a:result
-    if !filereadable(src) && !isdirectory(src)
-      echohl WarningMsg
-      echo printf('%s does not exist', src)
-      echohl None
-      continue
-    endif
-    call add(ps, fern#scheme#file#shutil#move(src, dst, token))
+    call add(fs, function('fern#scheme#file#shutil#move', [src, dst, token]))
   endfor
-  return s:Promise.all(ps)
+  return s:Promise.chain(fs)
         \.then({ -> fern#scheme#file#bufutil#moves(a:result) })
-        \.then({ -> len(ps) })
+        \.then({ -> len(fs) })
 endfunction

--- a/autoload/fern/scheme/file/mapping/rename.vim
+++ b/autoload/fern/scheme/file/mapping/rename.vim
@@ -45,7 +45,7 @@ function! s:map_rename(helper, opener) abort
         \ 'is_drawer': a:helper.sync.is_drawer(),
         \}
   let ns = {}
-  return fern#internal#renamer#rename(Factory, options)
+  return fern#internal#replacer#start(Factory, options)
         \.then({ r -> s:_map_rename(a:helper, r) })
         \.then({ n -> s:Lambda.let(ns, 'n', n) })
         \.then({ -> a:helper.async.collapse_modified_nodes(nodes) })

--- a/autoload/vital/fern.vital
+++ b/autoload/vital/fern.vital
@@ -1,5 +1,5 @@
 fern
-80887bd366c925887a40829eae73e86d7bb63ecc
+ffd4400d5a19716716e8f803dc5084db74033ffc
 
 App.Spinner
 Async.CancellationTokenSource

--- a/test/fern/internal/rename_solver.vimspec
+++ b/test/fern/internal/rename_solver.vimspec
@@ -1,0 +1,130 @@
+Describe fern#internal#rename_solver
+  Before all
+    let Exist = { -> 0 }
+    let Tempname = { p -> '@temp/' . p }
+    let IsDirectory = { -> 1 }
+  End
+
+  Describe #solve()
+    It solves "Simple renames"
+      let in = [
+            \ ['foo', 'a'],
+            \ ['bar', 'b'],
+            \]
+      let out = fern#internal#rename_solver#solve(in, {
+            \ 'exist': { p -> index(['foo', 'bar'], p) isnot# -1 },
+            \ 'tempname': Tempname,
+            \ 'isdirectory': IsDirectory,
+            \})
+      Assert Equals(out, [
+            \ ['foo', 'a'],
+            \ ['bar', 'b'],
+            \])
+    End
+
+    It solves "Nested renames"
+      let in = [
+            \ ['foo', 'bar'],
+            \ ['foo/a', 'bar/a'],
+            \ ['foo/b', 'bar/c'],
+            \]
+      let out = fern#internal#rename_solver#solve(in, {
+            \ 'exist': { p -> index(['foo', 'foo/a', 'foo/b'], p) isnot# -1 },
+            \ 'tempname': Tempname,
+            \ 'isdirectory': IsDirectory,
+            \})
+      Assert Equals(out, [
+            \ ['foo', 'bar'],
+            \ ['bar/b', 'bar/c'],
+            \])
+    End
+
+    It solves "Cross renames"
+      let in = [
+            \ ['foo', 'a/foo'],
+            \ ['foo/a', 'a'],
+            \]
+      let out = fern#internal#rename_solver#solve(in, {
+            \ 'exist': { p -> index(['foo', 'foo/a'], p) isnot# -1 },
+            \ 'tempname': Tempname,
+            \ 'isdirectory': IsDirectory,
+            \})
+      Assert Equals(out, [
+            \ ['foo/a', 'a'],
+            \ ['foo', 'a/foo'],
+            \])
+    End
+
+    It solves "Cyclic renames"
+      let in = [
+            \ ['foo', 'bar'],
+            \ ['bar', 'foo'],
+            \]
+      let out = fern#internal#rename_solver#solve(in, {
+            \ 'exist': { p -> index(['foo', 'bar'], p) isnot# -1 },
+            \ 'tempname': Tempname,
+            \ 'isdirectory': IsDirectory,
+            \})
+      Assert Equals(out, [
+            \ ['foo', '@temp/bar'],
+            \ ['bar', 'foo'],
+            \ ['@temp/bar', 'bar'],
+            \])
+    End
+
+    It solves "Nested cyclic renames"
+      let in = [
+            \ ['a', 'b'],
+            \ ['a/b', 'b/c'],
+            \ ['a/c', 'b/b'],
+            \]
+      let out = fern#internal#rename_solver#solve(in, {
+            \ 'exist': { p -> index(['a', 'a/b', 'a/c'], p) isnot# -1 },
+            \ 'tempname': Tempname,
+            \ 'isdirectory': IsDirectory,
+            \})
+      Assert Equals(out, [
+            \ ['a', 'b'],
+            \ ['b/b', '@temp/b/c'],
+            \ ['b/c', 'b/b'],
+            \ ['@temp/b/c', 'b/c'],
+            \])
+    End
+
+    It throws an error when destinations are not unique
+      let in = [
+            \ ['foo', 'baz'],
+            \ ['bar', 'baz'],
+            \]
+      Throws /more than once/ fern#internal#rename_solver#solve(in, {
+            \ 'exist': Exist,
+            \ 'tempname': Tempname,
+            \ 'isdirectory': IsDirectory,
+            \})
+    End
+
+    It throws an error on "Confclits with existing file"
+      let in = [
+            \ ['foo', 'bar'],
+            \ ['foo/a', 'bar/b'],
+            \]
+      Throws /already exist/ fern#internal#rename_solver#solve(in, {
+            \ 'exist': { p -> index(['foo', 'foo/a', 'foo/b'], p) isnot# -1 },
+            \ 'tempname': Tempname,
+            \ 'isdirectory': IsDirectory,
+            \})
+    End
+
+    It throws an error on "Rename into files"
+      let in = [
+            \ ['foo', 'a/foo'],
+            \ ['foo/a', 'a'],
+            \]
+      Throws /is not directory/ fern#internal#rename_solver#solve(in, {
+            \ 'exist': { p -> index(['foo', 'foo/a'], p) isnot# -1 },
+            \ 'tempname': Tempname,
+            \ 'isdirectory': { p -> index(['foo'], p) isnot# -1 },
+            \})
+    End
+  End
+End


### PR DESCRIPTION
This PR fix numerous rename issue on `rename` action of `file` and `dict` scheme.

# Cases fern support

## Simple renames

```
foo -> a
bar -> b
```

## Nested renames

```
foo   -> bar
foo/a -> bar/b
foo/c -> bar/c
```

## Cross renames

```
foo     -> a/foo
foo/a   -> a
```

## Cyclic renames

```
foo -> bar
bar -> foo
```

## Nested and Cyclic renames

```
a   -> b
a/b -> b/c
a/c -> b/b
```

# Cases fern warn and avoid

## Duplicate destinations

```
foo   -> bar
foo/a -> bar
```

## Conflicts with exsiting file

```
foo   -> bar
foo/a -> bar/b
```

Above renames on the follwoing tree should be avoided **before** actual renames.

```
foo
|- a
|- b
```

## Destination under non directory

```
foo   -> a/foo
foo/a -> a
```

Above fails if `foo/a` is file.
