### PR TITLE
add check v:version

### DIFF
--- a/plugin/fern.vim
+++ b/plugin/fern.vim
@@ -1,4 +1,4 @@
-if exists('g:loaded_fern')
+if exists('g:loaded_fern') || ( !has('nvim') && v:version < 801 )
   finish
 endif
 let g:loaded_fern = 1


### PR DESCRIPTION
If Vim version is earlier than 8.1, this plugin will not load.