### PR TITLE
Use current window position if the buffer of that window is same as target.

### DIFF
--- a/autoload/fern/helper.vim
+++ b/autoload/fern/helper.vim
@@ -7,7 +7,7 @@ function! fern#helper#new(...) abort
   let helper = extend({
         \ 'fern': fern,
         \ 'bufnr': bufnr,
-        \ 'winid': bufwinid(bufnr),
+        \ 'winid': bufnr() == bufnr ? win_getid() : bufwinid(bufnr),
         \}, s:helper)
   let helper.sync = fern#helper#sync#new(helper)
   let helper.async = fern#helper#async#new(helper)

--- a/autoload/fern/internal/spinner.vim
+++ b/autoload/fern/internal/spinner.vim
@@ -19,7 +19,7 @@ endfunction
 
 function! s:update(timer, spinner, bufnr) abort
   let fern = getbufvar(a:bufnr, 'fern', v:null)
-  let winid = bufwinid(a:bufnr)
+  let winid = bufnr() == a:bufnr ? win_getid() : bufwinid(a:bufnr)
   if fern is# v:null || winid is# -1
     call timer_stop(a:timer)
     return


### PR DESCRIPTION
# Problem

After splitting Fern window, this plugin uses the cursor position in first window whose buffer is target Fern buffer (`bufwinid(bufnr)`).

![two](https://user-images.githubusercontent.com/29811106/89679131-7b14c000-d92b-11ea-9bbc-cbdb2d022baf.gif)

# Solution

If focusing the window whose buffer is target Fern buffer, use a cursor position of that window.

![one](https://user-images.githubusercontent.com/29811106/89679004-2b35f900-d92b-11ea-84ca-01767f070b69.gif)
