### PR TITLE
Automatically duplicate the buffer on split/vsplit for convinience

### DIFF
--- a/autoload/fern.vim
+++ b/autoload/fern.vim
@@ -18,6 +18,7 @@ call s:Config.config(expand('<sfile>:p'), {
       \ 'keepalt_on_edit': 0,
       \ 'keepjumps_on_edit': 0,
       \ 'disable_default_mappings': 0,
+      \ 'disable_viewer_auto_duplication': 0,
       \ 'disable_drawer_auto_winfixwidth': 0,
       \ 'disable_drawer_auto_resize': 0,
       \ 'disable_drawer_auto_quit': 0,

--- a/autoload/fern/internal/viewer.vim
+++ b/autoload/fern/internal/viewer.vim
@@ -32,6 +32,7 @@ function! s:init() abort
   augroup fern_viewer_internal
     autocmd! * <buffer>
     autocmd BufEnter <buffer> setlocal nobuflisted
+    autocmd WinEnter <buffer> ++nested call s:WinEnter()
     autocmd BufReadCmd <buffer> ++nested call s:BufReadCmd()
     autocmd ColorScheme <buffer> call s:ColorScheme()
     autocmd CursorMoved,CursorMovedI,BufLeave <buffer> let b:fern_cursor = getcurpos()[1:2]
@@ -108,6 +109,18 @@ function! s:notify(bufnr, error) abort
       call notifier.reject([a:bufnr, a:error])
     endif
   endif
+endfunction
+
+function! s:WinEnter() abort
+  if len(win_findbuf(bufnr('%'))) < 2
+    return
+  endif
+  " Only one window is allowed to display one fern buffer.
+  " So create a new fern buffer with same options
+  let fri = fern#internal#bufname#parse(bufname('%'))
+  let fri.authority = ''
+  let bufname = fern#fri#format(fri)
+  execute printf('silent! keepalt edit %s$', fnameescape(bufname))
 endfunction
 
 function! s:BufReadCmd() abort

--- a/autoload/fern/internal/viewer.vim
+++ b/autoload/fern/internal/viewer.vim
@@ -120,7 +120,7 @@ function! s:WinEnter() abort
   let fri = fern#internal#bufname#parse(bufname('%'))
   let fri.authority = ''
   let bufname = fern#fri#format(fri)
-  execute printf('silent! keepalt edit %s$', fnameescape(bufname))
+  execute printf('silent! keepalt edit %s', fnameescape(bufname))
 endfunction
 
 function! s:BufReadCmd() abort

--- a/autoload/fern/internal/viewer.vim
+++ b/autoload/fern/internal/viewer.vim
@@ -32,10 +32,13 @@ function! s:init() abort
   augroup fern_viewer_internal
     autocmd! * <buffer>
     autocmd BufEnter <buffer> setlocal nobuflisted
-    autocmd WinEnter <buffer> ++nested call s:WinEnter()
     autocmd BufReadCmd <buffer> ++nested call s:BufReadCmd()
     autocmd ColorScheme <buffer> call s:ColorScheme()
     autocmd CursorMoved,CursorMovedI,BufLeave <buffer> let b:fern_cursor = getcurpos()[1:2]
+
+    if !g:fern#disable_viewer_auto_duplication
+      autocmd WinEnter <buffer> ++nested call s:WinEnter()
+    endif
   augroup END
 
   " Add unique fragment to make each buffer uniq

--- a/doc/fern.txt
+++ b/doc/fern.txt
@@ -375,6 +375,11 @@ VARIABLE						*fern-variable*
 	See |fern-action-mappings| for more detail.
 	Default: 0
 
+*g:fern#disable_viewer_auto_duplication*
+	Set 1 to disable viewer auto duplication on |WinEnter| autocmd.
+	The duplication is mainly occured when user execute |split| or
+	|vsplit| command to duplicate window.
+
 *g:fern#disable_drawer_auto_winfixwidth*
 	Set 1 to disable automatically enable 'winfixwidth' to drawer on
 	|BufEnter| autocmd.


### PR DESCRIPTION
![Kapture 2020-08-08 at 15 47 34](https://user-images.githubusercontent.com/546312/89704398-80572680-d98e-11ea-8303-728281e2bc14.gif)

Now fern automatically duplicate the buffer when user hit `split` or `vsplit` so that the content of each window can be different.
Users can disable this feature by `g:fern#disable_viewer_auto_duplication`