### PR TITLE
Improve "reveal" related features

### DIFF
--- a/autoload/fern/internal/command/fern.vim
+++ b/autoload/fern/internal/command/fern.vim
@@ -46,9 +46,6 @@ function! fern#internal#command#fern#command(mods, fargs) abort
       let opener = s:drawer_opener
     endif
 
-    " Resolve reveal
-    let reveal = empty(reveal) ? '' : expand(reveal)
-
     let expr = expand(a:fargs[0])
     let path = fern#fri#format(
           \ expr =~# '^[^:]\+://'
@@ -67,13 +64,6 @@ function! fern#internal#command#fern#command(mods, fargs) abort
           \ 'width': width,
           \ 'keep': keep,
           \})
-    let fri.fragment = empty(reveal) ? '' : fern#internal#filepath#to_slash(reveal)
-
-    " Normalize fragment if expr does not start from {scheme}://
-    if expr !~# '^[^:]\+://'
-      call s:norm_fragment(fri)
-    endif
-
     call fern#logger#debug('expr:', expr)
     call fern#logger#debug('fri:', fri)
 
@@ -126,17 +116,4 @@ function! fern#internal#command#fern#complete(arglead, cmdline, cursorpos) abort
     return fern#internal#complete#options(a:arglead, a:cmdline, a:cursorpos)
   endif
   return fern#internal#complete#url(a:arglead, a:cmdline, a:cursorpos)
-endfunction
-
-function! s:norm_fragment(fri) abort
-  if empty(a:fri.fragment)
-    return
-  endif
-  " fragment is one of the following
-  " 1) An absolute path of fs (/ in Unix, \ in Windows)
-  " 2) A relative path of fs (/ in Unix, \ in Windows)
-  " 3) A relative path of URI (/ in all platform)
-  let root = fern#fri#to#path(fern#fri#parse(a:fri.path))
-  let reveal = fern#internal#filepath#to_slash(a:fri.fragment)
-  let a:fri.fragment = fern#internal#path#relative(reveal, root)
 endfunction

--- a/autoload/fern/internal/command/fern.vim
+++ b/autoload/fern/internal/command/fern.vim
@@ -131,7 +131,7 @@ endfunction
 
 function! s:normalize_reveal(fri, reveal) abort
   let reveal = expand(a:reveal)
-  if a:reveal ==# reveal
+  if !fern#internal#filepath#is_absolute(reveal)
     return reveal
   endif
   " reveal points a real filesystem

--- a/autoload/fern/internal/complete.vim
+++ b/autoload/fern/internal/complete.vim
@@ -57,7 +57,8 @@ endfunction
 function! fern#internal#complete#reveal(arglead, cmdline, cursorpos) abort
   let scheme = matchstr(a:cmdline, '\<[^ :]\+\ze://')
   if empty(scheme)
-    let rs = getcompletion(matchstr(a:arglead, '^-reveal=\zs.*'), 'dir')
+    let rs = getcompletion(matchstr(a:arglead, '^-reveal=\zs.*'), 'file')
+    call map(rs, { _, v -> matchstr(v, '.\{-}\ze[/\\]\?$') })
     return map(rs, { _, v -> printf('-reveal=%s', escape(v, ' ')) })
   endif
   let rs = fern#internal#scheme#complete_reveal(scheme, a:arglead, a:cmdline, a:cursorpos)

--- a/autoload/fern/internal/viewer.vim
+++ b/autoload/fern/internal/viewer.vim
@@ -21,11 +21,7 @@ function! fern#internal#viewer#reveal(helper, path) abort
   return s:Promise.resolve()
         \.then({ -> a:helper.async.reveal_node(reveal) })
         \.then({ -> a:helper.async.redraw() })
-        \.then({ -> a:helper.sync.focus_node(
-        \   reveal,
-        \   { 'previous': previous },
-        \ )
-        \})
+        \.then({ -> a:helper.sync.focus_node(reveal) })
 endfunction
 
 function! s:open(bufname, options, resolve, reject) abort

--- a/autoload/fern/internal/viewer.vim
+++ b/autoload/fern/internal/viewer.vim
@@ -82,16 +82,12 @@ function! s:init() abort
     doautocmd <nomodeline> User FernSyntax
     call fern#internal#action#init()
 
-    let reveal = split(fri.fragment, '/')
     let Profile = fern#profile#start('fern#internal#viewer:init')
     return s:Promise.resolve()
           \.then({ -> helper.async.expand_node(root.__key) })
           \.finally({ -> Profile('expand') })
-          \.then({ -> helper.async.reveal_node(reveal) })
-          \.finally({ -> Profile('reveal') })
           \.then({ -> helper.async.redraw() })
           \.finally({ -> Profile('redraw') })
-          \.then({ -> helper.sync.focus_node(reveal) })
           \.finally({ -> Profile() })
           \.then({ -> fern#hook#emit('viewer:ready', helper) })
   catch

--- a/autoload/fern/internal/viewer.vim
+++ b/autoload/fern/internal/viewer.vim
@@ -17,10 +17,15 @@ endfunction
 function! fern#internal#viewer#reveal(helper, path) abort
   let path = fern#internal#filepath#to_slash(a:path)
   let reveal = split(path, '/')
+  let previous = a:helper.sync.get_cursor_node()
   return s:Promise.resolve()
         \.then({ -> a:helper.async.reveal_node(reveal) })
         \.then({ -> a:helper.async.redraw() })
-        \.then({ -> a:helper.sync.focus_node(reveal) })
+        \.then({ -> a:helper.sync.focus_node(
+        \   reveal,
+        \   { 'previous': previous },
+        \ )
+        \})
 endfunction
 
 function! s:open(bufname, options, resolve, reject) abort

--- a/autoload/fern/scheme/file/complete.vim
+++ b/autoload/fern/scheme/file/complete.vim
@@ -1,7 +1,8 @@
 function! fern#scheme#file#complete#url(arglead, cmdline, cursorpos) abort
   let path = '/' . fern#fri#parse(a:arglead).path
   let path = fern#internal#filepath#to_slash(path)
-  let rs = getcompletion(fern#internal#filepath#from_slash(path), 'dir')
+  let suffix = a:arglead =~# '/$' ? '/' : ''
+  let rs = getcompletion(fern#internal#filepath#from_slash(path) . suffix, 'dir')
   call map(rs, { -> fern#internal#filepath#to_slash(v:val) })
   call map(rs, { -> s:to_fri(v:val) })
   return rs
@@ -10,9 +11,15 @@ endfunction
 function! fern#scheme#file#complete#reveal(arglead, cmdline, cursorpos) abort
   let base = '/' . fern#fri#parse(matchstr(a:cmdline, '\<file:///\S*')).path
   let path = matchstr(a:arglead, '^-reveal=\zs.*')
-  let path = fern#internal#filepath#to_slash(path)
-  let path = fern#internal#path#absolute(path, base)
-  let rs = getcompletion(fern#internal#filepath#from_slash(path), 'dir')
+  if path ==# ''
+    let path = base
+    let suffix = '/'
+  else
+    let path = fern#internal#filepath#to_slash(path)
+    let path = fern#internal#path#absolute(path, base)
+    let suffix = a:arglead =~# '/$' ? '/' : ''
+  endif
+  let rs = getcompletion(fern#internal#filepath#from_slash(path) . suffix, 'file')
   call map(rs, { -> fern#internal#filepath#to_slash(v:val) })
   call map(rs, { -> fern#internal#path#relative(v:val, base) })
   call map(rs, { -> printf('-reveal=%s', v:val) })
@@ -23,7 +30,7 @@ function! s:to_fri(path) abort
   return fern#fri#format({
         \ 'scheme': 'file',
         \ 'authority': '',
-        \ 'path': a:path,
+        \ 'path': a:path[1:],
         \ 'query': {},
         \ 'fragment': '',
         \})

--- a/doc/fern.txt
+++ b/doc/fern.txt
@@ -494,6 +494,14 @@ COMMAND							*fern-command*
 	only a project drawer style fern.
 	Note that the command can be followed by a '|' and another command.
 
+							*:FernReveal*
+:FernReveal {reveal} [-wait]				BUFFER LOCAL
+	Reveal {reveal} on a current fern viewer. Note that this command
+	exists only in a fern viewer buffer.
+	If "-wait" option is specified, the command wait synchronously until
+	the node specified has revealed.
+	Note that the command can be followed by a '|' and another command.
+
 -----------------------------------------------------------------------------
 FUNCTION						*fern-function*
 


### PR DESCRIPTION
## Add `FernReveal` buffer local command

Fix #114 

Users can reveal a path on the current fern viewer with `FernReveal {reveal} [-wait]` command.
Use `FernDo` command to execute `FernReveal` from different buffer.

![Kapture 2020-08-12 at 2 44 13](https://user-images.githubusercontent.com/546312/89930499-cf7ab100-dc45-11ea-91d3-c02611232393.gif)

## `-reveal` option of `Fern` command always reveal the node

Fix #146 

![Kapture 2020-08-12 at 2 46 42](https://user-images.githubusercontent.com/546312/89930681-15d01000-dc46-11ea-957a-15ffaf8e3dc0.gif)
