### PR TITLE
Automatically hide cursor on fern viewer

### DIFF
--- a/autoload/fern.vim
+++ b/autoload/fern.vim
@@ -28,6 +28,7 @@ call s:Config.config(expand('<sfile>:p'), {
       \ 'keepjumps_on_edit': 0,
       \ 'disable_default_mappings': 0,
       \ 'disable_viewer_auto_duplication': 0,
+      \ 'disable_viewer_hide_cursor': 0,
       \ 'disable_drawer_auto_winfixwidth': 0,
       \ 'disable_drawer_auto_resize': 0,
       \ 'disable_drawer_auto_quit': 0,

--- a/autoload/fern/internal/cursor.vim
+++ b/autoload/fern/internal/cursor.vim
@@ -1,0 +1,52 @@
+let s:t_ve_saved = &t_ve
+let s:guicursor_saved = &guicursor
+
+function! fern#internal#cursor#hide() abort
+  call s:hide()
+endfunction
+
+function! fern#internal#cursor#restore() abort
+  call s:restore()
+endfunction
+
+if has('nvim')
+  if has('nvim-0.5.0')
+    " https://github.com/neovim/neovim/issues/3688#issuecomment-574544618
+    function! s:hide() abort
+      set guicursor+=a:FernTransparentCursor/lCursor
+    endfunction
+
+    function! s:restore() abort
+      set guicursor+=a:Cursor/lCursor
+      let &guicursor = s:guicursor_saved
+    endfunction
+
+    function! s:highlight() abort
+      highlight default FernTransparentCursor gui=strikethrough blend=100
+    endfunction
+    call s:highlight()
+
+    augroup fern_internal_cursor
+      autocmd!
+      autocmd ColorScheme * call s:highlight()
+    augroup END
+  else
+    " No way thus use narrow cursor instead
+    function! s:hide() abort
+      set guicursor+=a:ver1
+    endfunction
+
+    function! s:restore() abort
+      let &guicursor = s:guicursor_saved
+    endfunction
+  endif
+else
+  " Vim supports 't_ve'
+  function! s:hide() abort
+    set t_ve=
+  endfunction
+
+  function! s:restore() abort
+    let &t_ve = s:t_ve_saved
+  endfunction
+endif

--- a/autoload/fern/internal/viewer.vim
+++ b/autoload/fern/internal/viewer.vim
@@ -55,6 +55,11 @@ function! s:init() abort
     if !g:fern#disable_viewer_auto_duplication
       autocmd WinEnter <buffer> ++nested call s:WinEnter()
     endif
+
+    if !g:fern#disable_viewer_hide_cursor
+      autocmd BufEnter,WinEnter,CmdwinLeave,CmdlineLeave <buffer> call fern#internal#cursor#hide()
+      autocmd BufLeave,WinLeave,CmdwinEnter,CmdlineEnter <buffer> call fern#internal#cursor#restore()
+    endif
   augroup END
 
   " Add unique fragment to make each buffer uniq

--- a/doc/fern.txt
+++ b/doc/fern.txt
@@ -376,6 +376,10 @@ VARIABLE						*fern-variable*
 	The duplication is mainly occured when user execute |split| or
 	|vsplit| command to duplicate window.
 
+*g:fern#disable_viewer_hide_cursor*
+	Set 1 to disable viewer hide cursor. Note that Neovim prior to 0.5.0
+	cannot hide cursor thus the cursor is shown as a vertical bar instead.
+
 *g:fern#disable_drawer_auto_winfixwidth*
 	Set 1 to disable automatically enable 'winfixwidth' to drawer on
 	|BufEnter| autocmd.


### PR DESCRIPTION
Now fern automatically hide cursor on viewer. The feature can be disabled by `g:fern#disable_viewer_hide_cursor = 1`

### Before

![Alacritty 2020-08-20 13-50-34](https://user-images.githubusercontent.com/546312/90718191-4706ab00-e2ec-11ea-8099-496018f2c5c8.png)

### After

![Alacritty 2020-08-20 13-50-55](https://user-images.githubusercontent.com/546312/90718202-4c63f580-e2ec-11ea-943a-d376d57c9ff5.png)
