### PR TITLE
Fix invisible cursor issue

### DIFF
--- a/autoload/fern/internal/cursor.vim
+++ b/autoload/fern/internal/cursor.vim
@@ -17,7 +17,11 @@ if has('nvim')
     endfunction
 
     function! s:restore() abort
-      set guicursor+=a:Cursor/lCursor
+      " NOTE:
+      " The default 'Cursor' highlight is 'xxx guifg=bg guibg=fg' but it
+      " does NOT work and seems ignored. Thus use 'TermCursor' instead to
+      " fix #177
+      set guicursor+=a:TermCursor/lCursor
       let &guicursor = s:guicursor_saved
     endfunction
 

--- a/ftplugin/fern.vim
+++ b/ftplugin/fern.vim
@@ -5,3 +5,7 @@ let b:did_ftplugin = 1
 
 setlocal cursorline
 setlocal nolist nowrap nospell
+
+if exists('&cursorlineopt')
+  setlocal cursorlineopt=both
+endif


### PR DESCRIPTION
1. Cursor restore issue on Neovim with default colorscheme (#177)
2. Invisible cursor when `set cursorlineopt=number` on Vim