### PR TITLE
Allow user function to customize node label on default renderer

### DIFF
--- a/autoload/fern/renderer/default.vim
+++ b/autoload/fern/renderer/default.vim
@@ -76,7 +76,8 @@ endfunction
 function! s:render_node(node, base, options) abort
   let level = len(a:node.__key) - a:base
   if level is# 0
-    return a:options.root_symbol . a:node.label . '' . a:node.badge
+    let label = FernRendererCustomLabel(a:node, 1)
+    return a:options.root_symbol . label . '' . a:node.badge
   endif
   let leading = repeat(a:options.leading, level - 1)
   let symbol = a:node.status is# s:STATUS_NONE
@@ -85,7 +86,8 @@ function! s:render_node(node, base, options) abort
         \   ? a:options.collapsed_symbol
         \   : a:options.expanded_symbol
   let suffix = a:node.status ? '/' : ''
-  return leading . symbol . a:node.label . suffix . '' . a:node.badge
+  let label = FernRendererCustomLabel(a:node, 0)
+  return leading . symbol . label . suffix . '' . a:node.badge
 endfunction
 
 call s:Config.config(expand('<sfile>:p'), {
@@ -105,4 +107,10 @@ if exists('g:fern#renderer#default#marked_symbol')
 endif
 if exists('g:fern#renderer#default#unmarked_symbol')
   call fern#util#obsolete('g:fern#renderer#default#unmarked_symbol')
+endif
+
+if !exists('*FernRendererCustomLabel')
+  function FernRendererCustomLabel(node, is_root) abort
+    return a:node.label
+  endfunction
 endif

--- a/autoload/fern/renderer/default.vim
+++ b/autoload/fern/renderer/default.vim
@@ -38,19 +38,24 @@ function! s:lnum(index) abort
 endfunction
 
 function! s:syntax() abort
+  syntax match FernLeaf   /^.*[^/].*$/ transparent contains=FernLeafSymbol
+  syntax match FernBranch /^.*\/.*$/   transparent contains=FernBranchSymbol
+  syntax match FernRoot   /\%1l.*/       transparent contains=FernRootText
   execute printf(
-        \ 'syntax match FernRootSymbol /\%%1l%s/ nextgroup=FernRootText',
-        \ escape(g:fern#renderer#default#root_symbol, s:ESCAPE_PATTERN),
-        \)
+       \ 'syntax match FernRootSymbol /%s/ contained nextgroup=FernRootText',
+       \ escape(g:fern#renderer#default#root_symbol, s:ESCAPE_PATTERN),
+       \)
   execute printf(
-        \ 'syntax match FernLeafSymbol /^\s*%s/ nextgroup=FernLeafText',
-        \ escape(g:fern#renderer#default#leaf_symbol, s:ESCAPE_PATTERN),
-        \)
+       \ 'syntax match FernLeafSymbol /^\%%(%s\)*%s/ contained nextgroup=FernLeafText',
+       \ escape(g:fern#renderer#default#leading, s:ESCAPE_PATTERN),
+       \ escape(g:fern#renderer#default#leaf_symbol, s:ESCAPE_PATTERN),
+       \)
   execute printf(
-        \ 'syntax match FernBranchSymbol /^\s*\%%(%s\|%s\)/ nextgroup=FernBranchText',
-        \ escape(g:fern#renderer#default#collapsed_symbol, s:ESCAPE_PATTERN),
-        \ escape(g:fern#renderer#default#expanded_symbol, s:ESCAPE_PATTERN),
-        \)
+       \ 'syntax match FernBranchSymbol /^\%%(%s\)*\%%(%s\|%s\)/ contained nextgroup=FernBranchText',
+       \ escape(g:fern#renderer#default#leading, s:ESCAPE_PATTERN),
+       \ escape(g:fern#renderer#default#collapsed_symbol, s:ESCAPE_PATTERN),
+       \ escape(g:fern#renderer#default#expanded_symbol, s:ESCAPE_PATTERN),
+       \)
   syntax match FernRootText   /.*\ze.*$/ contained nextgroup=FernBadgeSep
   syntax match FernLeafText   /.*\ze.*$/ contained nextgroup=FernBadgeSep
   syntax match FernBranchText /.*\ze.*$/ contained nextgroup=FernBadgeSep
@@ -79,7 +84,8 @@ function! s:render_node(node, base, options) abort
         \ : a:node.status is# s:STATUS_COLLAPSED
         \   ? a:options.collapsed_symbol
         \   : a:options.expanded_symbol
-  return leading . symbol . a:node.label . '' . a:node.badge
+  let suffix = a:node.status ? '/' : ''
+  return leading . symbol . a:node.label . suffix . '' . a:node.badge
 endfunction
 
 call s:Config.config(expand('<sfile>:p'), {

--- a/doc/fern.txt
+++ b/doc/fern.txt
@@ -273,12 +273,28 @@ Users can customize above appearance by the following variables.
 *g:fern#renderer#default#unmarked_symbol*
 	OBSOLETE(v1.6.0)~
 	No alternative feature is provided.
-
 See |FernHighlight| and |fern-highlight| to change pre-defeined |highlight|.
 
 Or create user custom renderer to change the appearance completely.
 See |fern-develop-renderer| for more details.
 
+Users can customize the label by the following functions.
+
+						*FernRendererCustomLabel()*
+FernRendererCustomLabel({node}, {is_root})
+	A global function which is called to determine a label of the {node}.
+	The {node} is a node instance (|fern-develop-node|) and {is_root} is
+	|Boolean| to indicate that the {node} is root node. 
+	For example, if you'd like to show an absolute path on the root node
+	on file:// scheme, define the following function in your vimrc:
+>
+	function! FernRendererCustomLabel(node, is_root) abort
+	  if a:is_root && has_key(a:node, '_path')
+	    return fnamemodify(a:node._path, ':~')
+	  endif
+	  return a:node.label
+	endfunction
+<
 
 =============================================================================
 INTERFACE						*fern-interface*


### PR DESCRIPTION
**NOTE** I'm not really satisfied with the API yet.

To solve #178, I've added `FernRendererCustomLabel` function. Users can overwrite this function to customize label like

```vim
function! FernRendererCustomLabel(node, is_root) abort
  if a:is_root && has_key(a:node, '_path')
    return fnamemodify(a:node._path, ':~')
  endif
  return a:node.label
endfunction
```

![tmux 2020-08-28 01-29-35](https://user-images.githubusercontent.com/546312/91469120-f4ba2100-e8cd-11ea-81fc-529fab18a720.png)
