### PR TITLE
Fix highlight issue on the default renderer

### DIFF
--- a/autoload/fern/renderer/default.vim
+++ b/autoload/fern/renderer/default.vim
@@ -38,16 +38,21 @@ function! s:lnum(index) abort
 endfunction
 
 function! s:syntax() abort
+  syntax match FernLeaf   /^.*[^/].*$/ transparent contains=FernLeafSymbol
+  syntax match FernBranch /^.*\/.*$/   transparent contains=FernBranchSymbol
+  syntax match FernRoot   /\%1l.*/       transparent contains=FernRootText
   execute printf(
-        \ 'syntax match FernRootSymbol /\%%1l%s/ nextgroup=FernRootText',
+        \ 'syntax match FernRootSymbol /%s/ contained nextgroup=FernRootText',
         \ escape(g:fern#renderer#default#root_symbol, s:ESCAPE_PATTERN),
         \)
   execute printf(
-        \ 'syntax match FernLeafSymbol /^\s*%s/ nextgroup=FernLeafText',
+        \ 'syntax match FernLeafSymbol /^\%%(%s\)*%s/ contained nextgroup=FernLeafText',
+        \ escape(g:fern#renderer#default#leading, s:ESCAPE_PATTERN),
         \ escape(g:fern#renderer#default#leaf_symbol, s:ESCAPE_PATTERN),
         \)
   execute printf(
-        \ 'syntax match FernBranchSymbol /^\s*\%%(%s\|%s\)/ nextgroup=FernBranchText',
+        \ 'syntax match FernBranchSymbol /^\%%(%s\)*\%%(%s\|%s\)/ contained nextgroup=FernBranchText',
+        \ escape(g:fern#renderer#default#leading, s:ESCAPE_PATTERN),
         \ escape(g:fern#renderer#default#collapsed_symbol, s:ESCAPE_PATTERN),
         \ escape(g:fern#renderer#default#expanded_symbol, s:ESCAPE_PATTERN),
         \)
@@ -79,7 +84,8 @@ function! s:render_node(node, base, options) abort
         \ : a:node.status is# s:STATUS_COLLAPSED
         \   ? a:options.collapsed_symbol
         \   : a:options.expanded_symbol
-  return leading . symbol . a:node.label . '' . a:node.badge
+  let suffix = a:node.status ? '/' : ''
+  return leading . symbol . a:node.label . suffix . '' . a:node.badge
 endfunction
 
 call s:Config.config(expand('<sfile>:p'), {

--- a/test/behavior/Fern.vimspec
+++ b/test/behavior/Fern.vimspec
@@ -26,9 +26,9 @@ Describe Fern
       Assert Equals(winnr('$'), 1)
       Assert Equals(getline(1, '$'), [
             \ 'root',
-            \ '|+ deep',
-            \ '|+ heavy',
-            \ '|+ shallow',
+            \ '|+ deep/',
+            \ '|+ heavy/',
+            \ '|+ shallow/',
             \ '|  leaf',
             \])
     End
@@ -37,12 +37,12 @@ Describe Fern
       Fern debug:/// -reveal=deep/alpha/beta -wait
       Assert Equals(getline(1, '$'), [
             \ 'root',
-            \ '|- deep',
-            \ ' |- alpha',
-            \ '  |- beta',
+            \ '|- deep/',
+            \ ' |- alpha/',
+            \ '  |- beta/',
             \ '   |  gamma',
-            \ '|+ heavy',
-            \ '|+ shallow',
+            \ '|+ heavy/',
+            \ '|+ shallow/',
             \ '|  leaf',
             \])
     End
@@ -51,11 +51,11 @@ Describe Fern
       Fern debug:/// -reveal=deep/alpha/zeta -wait
       Assert Equals(getline(1, '$'), [
             \ 'root',
-            \ '|- deep',
-            \ ' |- alpha',
-            \ '  |+ beta',
-            \ '|+ heavy',
-            \ '|+ shallow',
+            \ '|- deep/',
+            \ ' |- alpha/',
+            \ '  |+ beta/',
+            \ '|+ heavy/',
+            \ '|+ shallow/',
             \ '|  leaf',
             \])
     End
@@ -66,8 +66,8 @@ Describe Fern
       execute printf('Fern %s -wait', fnameescape(workdir))
       Assert Equals(winnr('$'), 1)
       Assert Equals(getline(2, '$'), [
-            \ '|+ deep',
-            \ '|+ shallow',
+            \ '|+ deep/',
+            \ '|+ shallow/',
             \ '|  leaf',
             \])
     End
@@ -76,11 +76,11 @@ Describe Fern
       execute printf('Fern %s -reveal=deep/alpha/beta -wait', fnameescape(workdir))
       Assert Equals(winnr('$'), 1)
       Assert Equals(getline(2, '$'), [
-            \ '|- deep',
-            \ ' |- alpha',
-            \ '  |- beta',
+            \ '|- deep/',
+            \ ' |- alpha/',
+            \ '  |- beta/',
             \ '   |  gamma',
-            \ '|+ shallow',
+            \ '|+ shallow/',
             \ '|  leaf',
             \])
     End
@@ -93,11 +93,11 @@ Describe Fern
             \)
       Assert Equals(winnr('$'), 1)
       Assert Equals(getline(2, '$'), [
-            \ '|- deep',
-            \ ' |- alpha',
-            \ '  |- beta',
+            \ '|- deep/',
+            \ ' |- alpha/',
+            \ '  |- beta/',
             \ '   |  gamma',
-            \ '|+ shallow',
+            \ '|+ shallow/',
             \ '|  leaf',
             \])
     End
@@ -110,11 +110,11 @@ Describe Fern
             \)
       Assert Equals(winnr('$'), 1)
       Assert Equals(getline(2, '$'), [
-            \ '|- deep',
-            \ ' |- alpha',
-            \ '  |- beta',
+            \ '|- deep/',
+            \ ' |- alpha/',
+            \ '  |- beta/',
             \ '   |  gamma',
-            \ '|+ shallow',
+            \ '|+ shallow/',
             \ '|  leaf',
             \])
     End

--- a/test/behavior/special-characters.vimspec
+++ b/test/behavior/special-characters.vimspec
@@ -31,35 +31,35 @@ Describe special-characters
     endif
     execute printf('Fern %s -wait', fnameescape(Join([workdir, ';'])))
     Assert Equals(getline(2, '$'), [
-          \ '|+ hello',
+          \ '|+ hello/',
           \])
   End
 
   It Fern {workdir}/# opens the directory
     execute printf('Fern %s -wait', fnameescape(Join([workdir, '#'])))
     Assert Equals(getline(2, '$'), [
-          \ '|+ hello',
+          \ '|+ hello/',
           \])
   End
 
   It Fern {workdir}/$ opens the directory
     execute printf('Fern %s -wait', fnameescape(Join([workdir, '$'])))
     Assert Equals(getline(2, '$'), [
-          \ '|+ hello',
+          \ '|+ hello/',
           \])
   End
 
   It Fern {workdir}/% opens the directory
     execute printf('Fern %s -wait', fnameescape(Join([workdir, '%'])))
     Assert Equals(getline(2, '$'), [
-          \ '|+ hello',
+          \ '|+ hello/',
           \])
   End
 
   It Fern {workdir}/%20 opens the directory
     execute printf('Fern %s -wait', fnameescape(Join([workdir, '%20'])))
     Assert Equals(getline(2, '$'), [
-          \ '|+ hello',
+          \ '|+ hello/',
           \])
   End
 End

--- a/test/fern/renderer/default.vimspec
+++ b/test/fern/renderer/default.vimspec
@@ -40,9 +40,9 @@ Describe fern#renderer#default
         Assert Equals(e, v:null)
         Assert Equals(r, [
               \ 'root',
-              \ '|- shallow',
-              \ ' |+ alpha',
-              \ ' |+ beta',
+              \ '|- shallow/',
+              \ ' |+ alpha/',
+              \ ' |+ beta/',
               \ ' |  gamma',
               \])
       End
@@ -59,9 +59,9 @@ Describe fern#renderer#default
         Assert Equals(e, v:null)
         Assert Equals(r, [
               \ 'root',
-              \ '|- shallow',
-              \ ' |+ alpha',
-              \ ' |+ beta',
+              \ '|- shallow/',
+              \ ' |+ alpha/',
+              \ ' |+ beta/',
               \ ' |  gamma',
               \])
       End


### PR DESCRIPTION
```vim
  let g:fern#renderer#default#leading = "│"
  let g:fern#renderer#default#root_symbol = "┬─ "
  let g:fern#renderer#default#leaf_symbol = "├─ "
  let g:fern#renderer#default#collapsed_symbol = "├─ "
  let g:fern#renderer#default#expanded_symbol = "├┬ "
```

### Before
![](https://user-images.githubusercontent.com/546312/91680692-ffeba600-eb86-11ea-8c27-5cc7834d6bc8.png)

### After
![tmux 2020-08-31 12-41-28](https://user-images.githubusercontent.com/546312/91680805-6a9ce180-eb87-11ea-8688-d8d60d085cf5.png)