### PR TITLE
Add core:xxxxx hooks to modify nodes/marks

### DIFF
--- a/autoload/fern/internal/core.vim
+++ b/autoload/fern/internal/core.vim
@@ -39,6 +39,7 @@ function! fern#internal#core#cancel(fern) abort
 endfunction
 
 function! fern#internal#core#update_nodes(fern, nodes) abort
+  call fern#hook#emit('core:update_nodes', a:nodes)
   let a:fern.nodes = a:nodes
   let include = a:fern.include
   let exclude = a:fern.exclude
@@ -59,6 +60,7 @@ function! fern#internal#core#update_nodes(fern, nodes) abort
         \.finally({ -> Profile('include') })
         \.then(s:AsyncLambda.filter_f(Exclude))
         \.finally({ -> Profile('exclude') })
+        \.then({ ns -> s:Lambda.pass(ns, fern#hook#emit('core:update_visible_nodes', ns)) })
         \.then({ ns -> s:Lambda.let(a:fern, 'visible_nodes', ns) })
         \.finally({ -> Profile('let') })
         \.then({ -> fern#internal#core#update_marks(a:fern, a:fern.marks) })
@@ -73,6 +75,7 @@ function! fern#internal#core#update_marks(fern, marks) abort
         \.finally({ -> Profile('key') })
         \.then({ ks -> s:AsyncLambda.filter(a:marks, { m -> index(ks, m) isnot# -1 }) })
         \.finally({ -> Profile('filter') })
+        \.then({ ms -> s:Lambda.pass(ms, fern#hook#emit('core:update_marks', ms)) })
         \.then({ ms -> s:Lambda.let(a:fern, 'marks', ms) })
         \.finally({ -> Profile() })
 endfunction

--- a/doc/fern-develop.txt
+++ b/doc/fern-develop.txt
@@ -262,6 +262,30 @@ HOOK						*fern-develop-hook*
 
 Following hook will be emitted by |fern#hook#emit()| from fern itself.
 
+"core:update_nodes" ({nodes})
+	Called when the nodes are updated.
+	The {nodes} is a |List| of |fern-develop-node|.
+	Overwrite the instance to apply changes.
+
+"core:update_visible_nodes" ({nodes})
+	Called when the visible nodes are updated.
+	The {nodes} is a |List| of |fern-develop-node|.
+	Overwrite the instance to apply changes like:
+>
+	function! s:update_root(nodes) abort
+	  if empty(a:nodes)
+	    return
+	  endif
+	  let root = a:nodes[0]
+	  let root.label = get(root, '_path', root.label)
+	endfunction
+	call fern#hook#add('core:update_visible_nodes', funcref('s:update_root'))
+<
+"core:update_marks" ({marks})
+	Called when marks are updated.
+	The {marks} is a |List| of |String| which indicates the marked nodes.
+	Overwrite the instance to apply changes.
+
 "viewer:syntax" ({helper})
 	Called when fern viewer has registered the syntax.
 	The {helper} is a helper instance described in |fern-develop-helper|.

--- a/doc/fern-develop.txt
+++ b/doc/fern-develop.txt
@@ -277,7 +277,9 @@ Following hook will be emitted by |fern#hook#emit()| from fern itself.
 	    return
 	  endif
 	  let root = a:nodes[0]
-	  let root.label = get(root, '_path', root.label)
+	  let root.label = has_key(root, '_path')
+	        \ ? fnamemodify(root._path, ':~')
+	        \ : root.label
 	endfunction
 	call fern#hook#add('core:update_visible_nodes', funcref('s:update_root'))
 <


### PR DESCRIPTION
Now users can use `core:update_nodes` or `core:update_visible_nodes` hooks to modify nodes directly. Or `core:update_marks` to modify marks.

This feature can be used to rewrite `label` attribute of nodes to satisfy the request on #178 like

![Alacritty 2020-08-31 19-41-39](https://user-images.githubusercontent.com/546312/91712076-ffbccc00-ebc1-11ea-908a-16d41282a014.png)

```vim
function! s:update_root(nodes) abort
  if empty(a:nodes)
    return
  endif
  let root = a:nodes[0]
  let root.label = has_key(root, '_path')
        \ ? fnamemodify(root._path, ':~')
        \ : root.label
endfunction

  call fern#hook#add(
        \ 'core:update_visible_nodes',
        \ funcref('s:update_root'),
        \)
```

This is documented in `fern-developer.txt` instead of `fern.txt` while it's a bit complicated feature and I think only power-users can use it. I don't want to support beginners about this feature.