### PR TITLE
Rename hidden/mark mappings/actions (previous one become deprecated)

### DIFF
--- a/autoload/fern/action.vim
+++ b/autoload/fern/action.vim
@@ -1,4 +1,13 @@
 let s:Action = vital#fern#import('App.Action')
+call s:Action.set_ignores([
+      \ 'hidden-set',
+      \ 'hidden-unset',
+      \ 'hidden-toggle',
+      \ 'mark-clear',
+      \ 'mark-set',
+      \ 'mark-unset',
+      \ 'mark-toggle',
+      \])
 
 function! fern#action#_init() abort
   call s:Action.init()

--- a/autoload/fern/mapping.vim
+++ b/autoload/fern/mapping.vim
@@ -21,6 +21,17 @@ function! fern#mapping#init(scheme) abort
   call fern#internal#scheme#mapping_init(a:scheme, disable_default_mappings)
 endfunction
 
+function! fern#mapping#deprecated(old, new) abort
+  call fern#util#deprecated(
+        \ printf('<Plug>(%s)', a:old),
+        \ printf('<Plug>(%s)', a:new),
+        \)
+  " Do NOT show the warning message more than once
+  silent execute printf('nmap <buffer> <Plug>(%s) <Plug>(%s)', a:old, a:new)
+  " Return new mapping
+  return printf("\<Plug>(%s)", a:new)
+endfunction
+
 call s:Config.config(expand('<sfile>:p'), {
       \ 'mappings': [
       \   'drawer',

--- a/autoload/fern/mapping/filter.vim
+++ b/autoload/fern/mapping/filter.vim
@@ -1,15 +1,26 @@
 function! fern#mapping#filter#init(disable_default_mappings) abort
-  nnoremap <buffer><silent> <Plug>(fern-action-hidden-set)    :<C-u>call <SID>call('hidden_set')<CR>
-  nnoremap <buffer><silent> <Plug>(fern-action-hidden-unset)  :<C-u>call <SID>call('hidden_unset')<CR>
-  nnoremap <buffer><silent> <Plug>(fern-action-hidden-toggle) :<C-u>call <SID>call('hidden_toggle')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-hidden:set)    :<C-u>call <SID>call('hidden_set')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-hidden:unset)  :<C-u>call <SID>call('hidden_unset')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-hidden:toggle) :<C-u>call <SID>call('hidden_toggle')<CR>
   nnoremap <buffer><silent> <Plug>(fern-action-include)     :<C-u>call <SID>call('include')<CR>
   nnoremap <buffer><silent> <Plug>(fern-action-exclude)     :<C-u>call <SID>call('exclude')<CR>
 
+  " Alias
+  nmap <buffer> <Plug>(fern-action-hidden) <Plug>(fern-action-hidden:toggle)
+
   if !a:disable_default_mappings
-    nmap <buffer><nowait> !  <Plug>(fern-action-hidden-toggle)
+    nmap <buffer><nowait> !  <Plug>(fern-action-hidden)
     nmap <buffer><nowait> fi <Plug>(fern-action-include)
     nmap <buffer><nowait> fe <Plug>(fern-action-exclude)
   endif
+
+  " DEPRECATED:
+  nmap <buffer><silent><expr> <Plug>(fern-action-hidden-set)
+        \ fern#mapping#deprecated('fern-action-hidden-set', 'fern-action-hidden:set')
+  nmap <buffer><silent><expr> <Plug>(fern-action-hidden-unset)
+        \ fern#mapping#deprecated('fern-action-hidden-unset', 'fern-action-hidden:unset')
+  nmap <buffer><silent><expr> <Plug>(fern-action-hidden-toggle)
+        \ fern#mapping#deprecated('fern-action-hidden-toggle', 'fern-action-hidden:toggle')
 endfunction
 
 function! s:call(name, ...) abort

--- a/autoload/fern/mapping/mark.vim
+++ b/autoload/fern/mapping/mark.vim
@@ -1,20 +1,42 @@
 let s:Promise = vital#fern#import('Async.Promise')
 
 function! fern#mapping#mark#init(disable_default_mappings) abort
-  nnoremap <buffer><silent> <Plug>(fern-action-mark-clear)  :<C-u>call <SID>call('mark_clear')<CR>
-  nnoremap <buffer><silent> <Plug>(fern-action-mark-toggle) :<C-u>call <SID>call('mark_toggle')<CR>
-  nnoremap <buffer><silent> <Plug>(fern-action-mark-set)    :<C-u>call <SID>call('mark_set')<CR>
-  nnoremap <buffer><silent> <Plug>(fern-action-mark-unset   :<C-u>call <SID>call('mark_unset')<CR>
-  vnoremap <buffer><silent> <Plug>(fern-action-mark-set)    :call <SID>call('mark_set')<CR>
-  vnoremap <buffer><silent> <Plug>(fern-action-mark-unset)  :call <SID>call('mark_unset')<CR>
-  vnoremap <buffer><silent> <Plug>(fern-action-mark-toggle) :call <SID>call('mark_toggle')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-mark:clear)  :<C-u>call <SID>call('mark_clear')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-mark:set)    :<C-u>call <SID>call('mark_set')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-mark:unset   :<C-u>call <SID>call('mark_unset')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-mark:toggle) :<C-u>call <SID>call('mark_toggle')<CR>
+  vnoremap <buffer><silent> <Plug>(fern-action-mark:set)    :call <SID>call('mark_set')<CR>
+  vnoremap <buffer><silent> <Plug>(fern-action-mark:unset)  :call <SID>call('mark_unset')<CR>
+  vnoremap <buffer><silent> <Plug>(fern-action-mark:toggle) :call <SID>call('mark_toggle')<CR>
+
+  " Alias
+  nmap <buffer> <Plug>(fern-action-mark) <Plug>(fern-action-mark:toggle)
+  vmap <buffer> <Plug>(fern-action-mark) <Plug>(fern-action-mark:toggle)
 
   if !a:disable_default_mappings
-    nmap <buffer><nowait> <C-j> <Plug>(fern-action-mark-toggle)j
-    nmap <buffer><nowait> <C-k> k<Plug>(fern-action-mark-toggle)
-    nmap <buffer><nowait> -     <Plug>(fern-action-mark-toggle)
-    vmap <buffer><nowait> -     <Plug>(fern-action-mark-toggle)
+    nmap <buffer><nowait> <C-j> <Plug>(fern-action-mark)j
+    nmap <buffer><nowait> <C-k> k<Plug>(fern-action-mark)
+    nmap <buffer><nowait> -     <Plug>(fern-action-mark)
+    vmap <buffer><nowait> -     <Plug>(fern-action-mark)
   endif
+
+  " DEPRECATED:
+  nmap <buffer><silent><expr> <Plug>(fern-action-mark-clear)
+        \ <SID>deprecated('fern-action-mark-clear', 'fern-action-mark:clear')
+  nmap <buffer><silent><expr> <Plug>(fern-action-mark-set)
+        \ <SID>deprecated('fern-action-mark-set', 'fern-action-mark:set')
+  nmap <buffer><silent><expr> <Plug>(fern-action-mark-unset)
+        \ <SID>deprecated('fern-action-mark-unset', 'fern-action-mark:unset')
+  nmap <buffer><silent><expr> <Plug>(fern-action-mark-toggle)
+        \ <SID>deprecated('fern-action-mark-toggle', 'fern-action-mark:toggle')
+  vmap <buffer><silent><expr> <Plug>(fern-action-mark-clear)
+        \ <SID>deprecated('fern-action-mark-clear', 'fern-action-mark:clear')
+  vmap <buffer><silent><expr> <Plug>(fern-action-mark-set)
+        \ <SID>deprecated('fern-action-mark-set', 'fern-action-mark:set')
+  vmap <buffer><silent><expr> <Plug>(fern-action-mark-unset)
+        \ <SID>deprecated('fern-action-mark-unset', 'fern-action-mark:unset')
+  vmap <buffer><silent><expr> <Plug>(fern-action-mark-toggle)
+        \ <SID>deprecated('fern-action-mark-toggle', 'fern-action-mark:toggle')
 endfunction
 
 function! s:call(name, ...) abort

--- a/autoload/fern/mapping/open.vim
+++ b/autoload/fern/mapping/open.vim
@@ -38,12 +38,6 @@ function! fern#mapping#open#init(disable_default_mappings) abort
         \   "\<Plug>(fern-action-expand)",
         \ )
 
-  " For backword compatibility
-  nmap <buffer><silent><expr> <Plug>(fern-open-or-enter)
-        \ <SID>deprecated('fern-open-or-enter', 'fern-action-open-or-enter')
-  nmap <buffer><silent><expr> <Plug>(fern-open-or-expand)
-        \ <SID>deprecated('fern-open-or-expand', 'fern-action-open-or-expand')
-
   " Alias map
   nmap <buffer><silent> <Plug>(fern-action-open:edit) <Plug>(fern-action-open:edit-or-error)
   nmap <buffer><silent> <Plug>(fern-action-open) <Plug>(fern-action-open:edit)
@@ -56,17 +50,12 @@ function! fern#mapping#open#init(disable_default_mappings) abort
     nmap <buffer><nowait> E <Plug>(fern-action-open:side)
     nmap <buffer><nowait> t <Plug>(fern-action-open:tabedit)
   endif
-endfunction
 
-function! s:deprecated(old, new) abort
-  call fern#util#deprecated(
-        \ printf('<Plug>(%s)', a:old),
-        \ printf('<Plug>(%s)', a:new),
-        \)
-  " Do NOT show the warning message more than once
-  silent execute printf('nmap <buffer> <Plug>(%s) <Plug>(%s)', a:old, a:new)
-  " Return new mapping
-  return printf("\<Plug>(%s)", a:new)
+  " DEPRECATED:
+  nmap <buffer><silent><expr> <Plug>(fern-open-or-enter)
+        \ fern#mapping#deprecated('fern-open-or-enter', 'fern-action-open-or-enter')
+  nmap <buffer><silent><expr> <Plug>(fern-open-or-expand)
+        \ fern#mapping#deprecated('fern-open-or-expand', 'fern-action-open-or-expand')
 endfunction
 
 function! s:call(name, ...) abort

--- a/doc/fern.txt
+++ b/doc/fern.txt
@@ -665,17 +665,30 @@ GLOBAL							*fern-mapping-global*
 	The original window width will be restored once user leave the window.
 	It only works on a drawer style fern window.
 
-*<Plug>(fern-action-hidden-set)*
+*<Plug>(fern-action-hidden:set)*
 	Show hidden nodes. For example hidden nodes in file:// scheme is a
 	file or directory starts from '.' character.
 	
-*<Plug>(fern-action-hidden-unset)*
+*<Plug>(fern-action-hidden:unset)*
 	Hide hidden nodes. For example hidden nodes in file:// scheme is a
 	file or directory starts from '.' character.
 
-*<Plug>(fern-action-hidden-toggle)*
+*<Plug>(fern-action-hidden:toggle)*
 	Toggle hidden nodes. For example hidden nodes in file:// scheme is a
 	file or directory starts from '.' character.
+
+*<Plug>(fern-action-hidden)*
+	An alias to "hidden:toggle" action. Users can overwrite this mapping
+	to change the default behavior of "hidden" action.
+
+*<Plug>(fern-action-hidden-set)*
+	DEPRECATED: Use |<Plug>(fern-action-hidden:set)| instead.
+	
+*<Plug>(fern-action-hidden-unset)*
+	DEPRECATED: Use |<Plug>(fern-action-hidden:unset)| instead.
+
+*<Plug>(fern-action-hidden-toggle)*
+	DEPRECATED: Use |<Plug>(fern-action-hidden:toggle)| instead.
 
 *<Plug>(fern-action-include)*
 	Open a prompt to enter include filter. Users can type a |pattern| to
@@ -685,17 +698,33 @@ GLOBAL							*fern-mapping-global*
 	Open a prompt to enter exclude filter. Users can type a |pattern| to
 	filter nodes recursively.
 
-*<Plug>(fern-action-mark-clear)*
+*<Plug>(fern-action-mark:clear)*
 	Clear existing marks.
 
-*<Plug>(fern-action-mark-toggle)*
-	Toggle marks on cursor node(s).
-
-*<Plug>(fern-action-mark-set)*
+*<Plug>(fern-action-mark:set)*
 	Set marks on cursor node(s).
 
-*<Plug>(fern-action-mark-unset)*
+*<Plug>(fern-action-mark:unset)*
 	Unset marks on cursor node(s).
+
+*<Plug>(fern-action-mark:toggle)*
+	Toggle marks on cursor node(s).
+
+*<Plug>(fern-action-mark)*
+	An alias to "mark:toggle" action. Users can overwrite this mapping to 
+	change the default behavior of "mark" action.
+
+*<Plug>(fern-action-mark-clear)*
+	DEPRECATED: Use |<Plug>(fern-action-mark:clear)| instead.
+
+*<Plug>(fern-action-mark-set)*
+	DEPRECATED: Use |<Plug>(fern-action-mark:set)| instead.
+
+*<Plug>(fern-action-mark-unset)*
+	DEPRECATED: Use |<Plug>(fern-action-mark:unset)| instead.
+
+*<Plug>(fern-action-mark-toggle)*
+	DEPRECATED: Use |<Plug>(fern-action-mark:toggle)| instead.
 
 *<Plug>(fern-action-debug)*
 	Echo debug information of a cursor node.


### PR DESCRIPTION
| Previous        | Current         |
| --------------- | --------------- |
| `hidden-set`    | `hidden:set`    |
| `hidden-unset`  | `hidden:unset`  |
| `hidden-toggle` | `hidden:toggle` |
| | `hidden` |
| `mark-clear`    | `mark:clear`    |
| `mark-set`      | `mark:set`      |
| `mark-unset`    | `mark:unset`    |
| `mark-toggle`   | `mark:toggle`   |
| | `mark` |

All previous mappings/actions become deprecated. Users should use the new one.