### PR TITLE
Add an option to show absolute path of "file" scheme root node

### DIFF
--- a/autoload/fern/scheme/file.vim
+++ b/autoload/fern/scheme/file.vim
@@ -1,0 +1,5 @@
+let s:Config = vital#fern#import('Config')
+
+call s:Config.config(expand('<sfile>:p'), {
+      \ 'show_absolute_path_on_root_label': 0,
+      \})

--- a/autoload/fern/scheme/file/provider.vim
+++ b/autoload/fern/scheme/file/provider.vim
@@ -31,7 +31,11 @@ function! s:provider_get_root(uri) abort
   if s:is_windows && path ==# ''
     return s:windows_drive_root
   endif
-  return s:node(path)
+  let root = s:node(path)
+  if g:fern#scheme#file#show_absolute_path_on_root_label
+    let root.label = fnamemodify(root._path, ':~')
+  endif
+  return root
 endfunction
 
 function! s:provider_get_parent(node, ...) abort

--- a/doc/fern.txt
+++ b/doc/fern.txt
@@ -429,6 +429,11 @@ VARIABLE						*fern-variable*
 	Note that users must restart Vim to apply changes.
 	Default: "*"
 
+*g:fern#scheme#file#show_absolute_path_on_root_label*
+	A |Boolean| to show an absolute path of the root node of "file" scheme
+	as a label of the node.
+	Default: 0
+
 -----------------------------------------------------------------------------
 COMMAND							*fern-command*
 


### PR DESCRIPTION
Close #178 

![tmux 2020-09-06 13-09-23](https://user-images.githubusercontent.com/546312/92318080-17c68e00-efbc-11ea-8677-456517b19cbc.png)

Add the following to enable the option

```vim
let g:fern#scheme#file#show_absolute_path_on_root_label = 1
```

The option **only affect the "file" scheme**.