### PR TITLE
Add expand:stay/expand:in actions

### DIFF
--- a/doc/fern.txt
+++ b/doc/fern.txt
@@ -782,8 +782,21 @@ GLOBAL							*fern-mapping-global*
 	      \ <Plug>(fern-action-reload)
 	      \ <Plug>(fern-action-reload:cursor)
 <
+*<Plug>(fern-action-expand:stay)*
+	Expand on a cursor node and stay the cursor on the node.
+
+*<Plug>(fern-action-expand:in)*
+	Expand on a cursor node and get in the cursor node (move on the first
+	child node of the cursor node.)
+
 *<Plug>(fern-action-expand)*
-	Expand on a cursor node.
+	An alias to "expand:in" action. Users can overwrite this mapping to
+	change the default behavior of "expand" action like:
+>
+	nmap <buffer> 
+	      \ <Plug>(fern-action-expand)
+	      \ <Plug>(fern-action-expand:stay)
+<
 
 *<Plug>(fern-action-collapse)*
 	Collapse on a cursor node.


### PR DESCRIPTION
To solve #210 

1. Add `expand:stay` action which does NOT move cursor (what @noscript suggested)
2. Add `expand:in` action which move cursor when the node has children (what @winkee01 suggested)
3. Alias `expand` action to `expand:in` for backward compatibility