### PR TITLE
Add 'yank' actions

### DIFF
--- a/autoload/fern/mapping.vim
+++ b/autoload/fern/mapping.vim
@@ -55,5 +55,6 @@ call s:Config.config(expand('<sfile>:p'), {
       \   'open',
       \   'tree',
       \   'wait',
+      \   'yank',
       \ ],
       \})

--- a/autoload/fern/mapping/yank.vim
+++ b/autoload/fern/mapping/yank.vim
@@ -1,0 +1,25 @@
+function! fern#mapping#yank#init(disable_default_mappings) abort
+  nnoremap <buffer><silent> <Plug>(fern-action-yank:label) :<C-u>call <SID>call('yank', 'label')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-yank:badge) :<C-u>call <SID>call('yank', 'badge')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-yank:bufname) :<C-u>call <SID>call('yank', 'bufname')<CR>
+
+  nmap <buffer> <Plug>(fern-action-yank) <Plug>(fern-action-yank:bufname)
+
+  if !a:disable_default_mappings
+    call fern#mapping#nmap('y', '<Plug>(fern-action-yank)')
+  endif
+endfunction
+
+function! s:call(name, ...) abort
+  return call(
+        \ 'fern#mapping#call',
+        \ [funcref(printf('s:map_%s', a:name))] + a:000,
+        \)
+endfunction
+
+function! s:map_yank(helper, attr) abort
+  let node = a:helper.sync.get_cursor_node()
+  let value = get(node, a:attr, '')
+  call setreg(v:register, value)
+  redraw | echo printf("The node '%s' has yanked.", a:attr)
+endfunction

--- a/autoload/fern/scheme/file/mapping.vim
+++ b/autoload/fern/scheme/file/mapping.vim
@@ -233,4 +233,5 @@ let g:fern#scheme#file#mapping#mappings = get(g:, 'fern#scheme#file#mapping#mapp
       \ 'rename',
       \ 'system',
       \ 'terminal',
+      \ 'yank',
       \])

--- a/autoload/fern/scheme/file/mapping/yank.vim
+++ b/autoload/fern/scheme/file/mapping/yank.vim
@@ -1,0 +1,19 @@
+function! fern#scheme#file#mapping#yank#init(disable_default_mappings) abort
+  nnoremap <buffer><silent> <Plug>(fern-action-yank:path) :<C-u>call <SID>call('yank_path')<CR>
+
+  nmap <buffer> <Plug>(fern-action-yank) <Plug>(fern-action-yank:path)
+endfunction
+
+function! s:call(name, ...) abort
+  return call(
+        \ 'fern#mapping#call',
+        \ [funcref(printf('s:map_%s', a:name))] + a:000,
+        \)
+endfunction
+
+function! s:map_yank_path(helper) abort
+  let node = a:helper.sync.get_cursor_node()
+  let value = node._path
+  call setreg(v:register, value)
+  redraw | echo "The node 'path' has yanked."
+endfunction

--- a/doc/fern.txt
+++ b/doc/fern.txt
@@ -891,6 +891,21 @@ GLOBAL							*fern-mapping-global*
 *<Plug>(fern-action-redraw)*
 	Redraw tree.
 
+*<Plug>(fern-action-yank:label)*
+*<Plug>(fern-action-yank:badge)*
+*<Plug>(fern-action-yank:bufname)*
+	Yank the node label, badge, or bufname.
+
+*<Plug>(fern-action-yank)*
+	An alias to "yank:bufname" action. Users can overwrite this mapping to
+	change the default behavior of "yank" action like:
+>
+	nmap <buffer> 
+	      \ <Plug>(fern-action-yank)
+	      \ <Plug>(fern-action-yank:label)
+<
+	Note that this mapping is overwritten in FILE scheme.
+
 *<Plug>(fern-wait)*
 	Wait until the fern buffer become ready which would opened just before 
 	this mapping. This is required while fern buffers are loaded 
@@ -1043,6 +1058,10 @@ The following mappings/actions are only available on file:// scheme.
 *<Plug>(fern-action-terminal)*
 	Open terminal window(s) on or on parent of a cursor node or marked 
 	nodes in similar manners of global "open" actions.
+
+*<Plug>(fern-action-yank:path)*
+	Yank the node path. In FILE scheme, |<Plug>(fern-action-yank)| is
+	aliased to this mapping.
 
 -----------------------------------------------------------------------------
 DICT							*fern-mapping-dict*


### PR DESCRIPTION
Now users can yank the path of the node (or bufname of the node in non file:// scheme) by `y`.