### PR TITLE
Revert "Use hasmapto to define built-in mappings" which cause mapping overwrite issue

### DIFF
--- a/autoload/fern/internal/viewer.vim
+++ b/autoload/fern/internal/viewer.vim
@@ -8,10 +8,14 @@ function! fern#internal#viewer#open(fri, options) abort
 endfunction
 
 function! fern#internal#viewer#init() abort
-  let bufnr = bufnr('%')
-  return s:init()
-        \.then({ -> s:notify(bufnr, v:null) })
-        \.catch({ e -> s:Lambda.pass(e, s:notify(bufnr, e)) })
+  try
+    let bufnr = bufnr('%')
+    return s:init()
+          \.then({ -> s:notify(bufnr, v:null) })
+          \.catch({ e -> s:Lambda.pass(s:Promise.reject(e), s:notify(bufnr, e)) })
+  catch
+    return s:Promise.reject(v:exception)
+  endtry
 endfunction
 
 function! fern#internal#viewer#reveal(helper, path) abort

--- a/autoload/fern/internal/viewer.vim
+++ b/autoload/fern/internal/viewer.vim
@@ -93,6 +93,7 @@ function! s:init() abort
     let helper = fern#helper#new()
     let root = helper.sync.get_root_node()
 
+    call fern#mapping#init(scheme)
     call fern#internal#drawer#init()
     call fern#internal#spinner#start()
     call helper.fern.renderer.highlight()
@@ -101,7 +102,6 @@ function! s:init() abort
 
     " now the buffer is ready so set filetype to emit FileType
     setlocal filetype=fern
-    call fern#mapping#init(scheme)
     call helper.fern.renderer.syntax()
     call fern#hook#emit('viewer:syntax', helper)
     doautocmd <nomodeline> User FernSyntax

--- a/autoload/fern/mapping.vim
+++ b/autoload/fern/mapping.vim
@@ -32,20 +32,6 @@ function! fern#mapping#deprecated(old, new) abort
   return printf("\<Plug>(%s)", a:new)
 endfunction
 
-function! fern#mapping#nmap(lhs, rhs) abort
-  if hasmapto(a:rhs, 'n')
-    return
-  endif
-  execute printf('nmap <buffer><nowait> %s %s', a:lhs, a:rhs)
-endfunction
-
-function! fern#mapping#vmap(lhs, rhs) abort
-  if hasmapto(a:rhs, 'v')
-    return
-  endif
-  execute printf('vmap <buffer><nowait> %s %s', a:lhs, a:rhs)
-endfunction
-
 call s:Config.config(expand('<sfile>:p'), {
       \ 'mappings': [
       \   'drawer',

--- a/autoload/fern/mapping/drawer.vim
+++ b/autoload/fern/mapping/drawer.vim
@@ -5,7 +5,7 @@ function! fern#mapping#drawer#init(disable_default_mappings) abort
   nmap <buffer> <Plug>(fern-action-zoom) <Plug>(fern-action-zoom:half)
 
   if !a:disable_default_mappings
-    call fern#mapping#nmap('z', '<Plug>(fern-action-zoom)')
+    nmap <buffer><nowait> z <Plug>(fern-action-zoom)
   endif
 endfunction
 

--- a/autoload/fern/mapping/filter.vim
+++ b/autoload/fern/mapping/filter.vim
@@ -9,9 +9,9 @@ function! fern#mapping#filter#init(disable_default_mappings) abort
   nmap <buffer> <Plug>(fern-action-hidden) <Plug>(fern-action-hidden:toggle)
 
   if !a:disable_default_mappings
-    call fern#mapping#nmap('!', '<Plug>(fern-action-hidden)')
-    call fern#mapping#nmap('fi', '<Plug>(fern-action-include)')
-    call fern#mapping#nmap('fe', '<Plug>(fern-action-exclude)')
+    nmap <buffer><nowait> !  <Plug>(fern-action-hidden)
+    nmap <buffer><nowait> fi <Plug>(fern-action-include)
+    nmap <buffer><nowait> fe <Plug>(fern-action-exclude)
   endif
 
   " DEPRECATED:

--- a/autoload/fern/mapping/mark.vim
+++ b/autoload/fern/mapping/mark.vim
@@ -14,8 +14,10 @@ function! fern#mapping#mark#init(disable_default_mappings) abort
   vmap <buffer> <Plug>(fern-action-mark) <Plug>(fern-action-mark:toggle)
 
   if !a:disable_default_mappings
-    call fern#mapping#nmap('-', '<Plug>(fern-action-mark)')
-    call fern#mapping#vmap('-', '<Plug>(fern-action-mark)')
+    nmap <buffer><nowait> <C-j> <Plug>(fern-action-mark)j
+    nmap <buffer><nowait> <C-k> k<Plug>(fern-action-mark)
+    nmap <buffer><nowait> -     <Plug>(fern-action-mark)
+    vmap <buffer><nowait> -     <Plug>(fern-action-mark)
   endif
 
   " DEPRECATED:

--- a/autoload/fern/mapping/node.vim
+++ b/autoload/fern/mapping/node.vim
@@ -17,12 +17,14 @@ function! fern#mapping#node#init(disable_default_mappings) abort
   nmap <buffer> <Plug>(fern-action-expand) <Plug>(fern-action-expand:in)
 
   if !a:disable_default_mappings
-    call fern#mapping#nmap('<F5>', '<Plug>(fern-action-reload)')
-    call fern#mapping#nmap('<Return>', '<Plug>(fern-action-enter)')
-    call fern#mapping#nmap('<Backspace>', '<Plug>(fern-action-leave)')
-    call fern#mapping#nmap('l', '<Plug>(fern-action-expand)')
-    call fern#mapping#nmap('h', '<Plug>(fern-action-collapse)')
-    call fern#mapping#nmap('i', '<Plug>(fern-action-reveal)')
+    nmap <buffer><nowait> <F5> <Plug>(fern-action-reload)
+    nmap <buffer><nowait> <C-m> <Plug>(fern-action-enter)
+    nmap <buffer><nowait> <C-h> <Plug>(fern-action-leave)
+    nmap <buffer><nowait> l <Plug>(fern-action-expand)
+    nmap <buffer><nowait> h <Plug>(fern-action-collapse)
+    nmap <buffer><nowait> i <Plug>(fern-action-reveal)
+    nmap <buffer><nowait> <Return> <C-m>
+    nmap <buffer><nowait> <Backspace> <C-h>
   endif
 endfunction
 

--- a/autoload/fern/mapping/open.vim
+++ b/autoload/fern/mapping/open.vim
@@ -43,12 +43,12 @@ function! fern#mapping#open#init(disable_default_mappings) abort
   nmap <buffer><silent> <Plug>(fern-action-open) <Plug>(fern-action-open:edit)
 
   if !a:disable_default_mappings
-    call fern#mapping#nmap('<Return>', '<Plug>(fern-action-open-or-enter)')
-    call fern#mapping#nmap('l', '<Plug>(fern-action-open-or-expand)')
-    call fern#mapping#nmap('s', '<Plug>(fern-action-open:select)')
-    call fern#mapping#nmap('e', '<Plug>(fern-action-open)')
-    call fern#mapping#nmap('E', '<Plug>(fern-action-open:side)')
-    call fern#mapping#nmap('t', '<Plug>(fern-action-open:tabedit)')
+    nmap <buffer><nowait> <C-m> <Plug>(fern-action-open-or-enter)
+    nmap <buffer><nowait> l <Plug>(fern-action-open-or-expand)
+    nmap <buffer><nowait> s <Plug>(fern-action-open:select)
+    nmap <buffer><nowait> e <Plug>(fern-action-open)
+    nmap <buffer><nowait> E <Plug>(fern-action-open:side)
+    nmap <buffer><nowait> t <Plug>(fern-action-open:tabedit)
   endif
 
   " DEPRECATED:

--- a/autoload/fern/mapping/tree.vim
+++ b/autoload/fern/mapping/tree.vim
@@ -6,8 +6,8 @@ function! fern#mapping#tree#init(disable_default_mappings) abort
   nnoremap <buffer><silent> <Plug>(fern-action-redraw) :<C-u>call <SID>call('redraw')<CR>
 
   if !a:disable_default_mappings
-    call fern#mapping#nmap('<C-c>', '<Plug>(fern-action-cancel)')
-    call fern#mapping#nmap('<C-l>', '<Plug>(fern-action-redraw)')
+    nmap <buffer><nowait> <C-c> <Plug>(fern-action-cancel)
+    nmap <buffer><nowait> <C-l> <Plug>(fern-action-redraw)
   endif
 endfunction
 

--- a/autoload/fern/mapping/yank.vim
+++ b/autoload/fern/mapping/yank.vim
@@ -6,7 +6,7 @@ function! fern#mapping#yank#init(disable_default_mappings) abort
   nmap <buffer> <Plug>(fern-action-yank) <Plug>(fern-action-yank:bufname)
 
   if !a:disable_default_mappings
-    call fern#mapping#nmap('y', '<Plug>(fern-action-yank)')
+    nmap <buffer><nowait> y <Plug>(fern-action-yank)
   endif
 endfunction
 

--- a/autoload/fern/scheme/dict/mapping.vim
+++ b/autoload/fern/scheme/dict/mapping.vim
@@ -10,12 +10,12 @@ function! fern#scheme#dict#mapping#init(disable_default_mappings) abort
   nnoremap <buffer><silent> <Plug>(fern-action-edit-leaf)  :<C-u>call <SID>call('edit_leaf')<CR>
 
   if !a:disable_default_mappings
-    call fern#mapping#nmap('N', '<Plug>(fern-action-new-leaf)')
-    call fern#mapping#nmap('K', '<Plug>(fern-action-new-branch)')
-    call fern#mapping#nmap('c', '<Plug>(fern-action-copy)')
-    call fern#mapping#nmap('m', '<Plug>(fern-action-move)')
-    call fern#mapping#nmap('D', '<Plug>(fern-action-remove)')
-    call fern#mapping#nmap('e', '<Plug>(fern-action-edit-leaf)')
+    nmap <buffer><nowait> N <Plug>(fern-action-new-leaf)
+    nmap <buffer><nowait> K <Plug>(fern-action-new-branch)
+    nmap <buffer><nowait> c <Plug>(fern-action-copy)
+    nmap <buffer><nowait> m <Plug>(fern-action-move)
+    nmap <buffer><nowait> D <Plug>(fern-action-remove)
+    nmap <buffer><nowait> e <Plug>(fern-action-edit-leaf)
   endif
 endfunction
 

--- a/autoload/fern/scheme/dict/mapping/clipboard.vim
+++ b/autoload/fern/scheme/dict/mapping/clipboard.vim
@@ -13,9 +13,9 @@ function! fern#scheme#dict#mapping#clipboard#init(disable_default_mappings) abor
   nnoremap <buffer><silent> <Plug>(fern-action-clipboard-clear) :<C-u>call <SID>call('clipboard_clear')<CR>
 
   if !a:disable_default_mappings
-    call fern#mapping#nmap('C', '<Plug>(fern-action-clipboard-copy)')
-    call fern#mapping#nmap('M', '<Plug>(fern-action-clipboard-move)')
-    call fern#mapping#nmap('P', '<Plug>(fern-action-clipboard-paste)')
+    nmap <buffer><nowait> C <Plug>(fern-action-clipboard-copy)
+    nmap <buffer><nowait> M <Plug>(fern-action-clipboard-move)
+    nmap <buffer><nowait> P <Plug>(fern-action-clipboard-paste)
   endif
 endfunction
 

--- a/autoload/fern/scheme/dict/mapping/rename.vim
+++ b/autoload/fern/scheme/dict/mapping/rename.vim
@@ -24,7 +24,7 @@ function! fern#scheme#dict#mapping#rename#init(disable_default_mappings) abort
   nmap <buffer><silent> <Plug>(fern-action-rename) <Plug>(fern-action-rename:split)
 
   if !a:disable_default_mappings
-    call fern#mapping#nmap('R', '<Plug>(fern-action-rename)')
+    nmap <buffer><nowait> R <Plug>(fern-action-rename)
   endif
 endfunction
 

--- a/autoload/fern/scheme/file/mapping.vim
+++ b/autoload/fern/scheme/file/mapping.vim
@@ -11,11 +11,11 @@ function! fern#scheme#file#mapping#init(disable_default_mappings) abort
   nnoremap <buffer><silent> <Plug>(fern-action-remove)   :<C-u>call <SID>call('remove')<CR>
 
   if !a:disable_default_mappings
-    call fern#mapping#nmap('N', '<Plug>(fern-action-new-file)')
-    call fern#mapping#nmap('K', '<Plug>(fern-action-new-dir)')
-    call fern#mapping#nmap('c', '<Plug>(fern-action-copy)')
-    call fern#mapping#nmap('m', '<Plug>(fern-action-move)')
-    call fern#mapping#nmap('D', '<Plug>(fern-action-trash)')
+    nmap <buffer><nowait> N <Plug>(fern-action-new-file)
+    nmap <buffer><nowait> K <Plug>(fern-action-new-dir)
+    nmap <buffer><nowait> c <Plug>(fern-action-copy)
+    nmap <buffer><nowait> m <Plug>(fern-action-move)
+    nmap <buffer><nowait> D <Plug>(fern-action-trash)
   endif
 endfunction
 

--- a/autoload/fern/scheme/file/mapping/clipboard.vim
+++ b/autoload/fern/scheme/file/mapping/clipboard.vim
@@ -13,9 +13,9 @@ function! fern#scheme#file#mapping#clipboard#init(disable_default_mappings) abor
   nnoremap <buffer><silent> <Plug>(fern-action-clipboard-clear) :<C-u>call <SID>call('clipboard_clear')<CR>
 
   if !a:disable_default_mappings
-    call fern#mapping#nmap('C', '<Plug>(fern-action-clipboard-copy)')
-    call fern#mapping#nmap('M', '<Plug>(fern-action-clipboard-move)')
-    call fern#mapping#nmap('P', '<Plug>(fern-action-clipboard-paste)')
+    nmap <buffer><nowait> C <Plug>(fern-action-clipboard-copy)
+    nmap <buffer><nowait> M <Plug>(fern-action-clipboard-move)
+    nmap <buffer><nowait> P <Plug>(fern-action-clipboard-paste)
   endif
 endfunction
 

--- a/autoload/fern/scheme/file/mapping/rename.vim
+++ b/autoload/fern/scheme/file/mapping/rename.vim
@@ -24,7 +24,7 @@ function! fern#scheme#file#mapping#rename#init(disable_default_mappings) abort
   nmap <buffer><silent> <Plug>(fern-action-rename) <Plug>(fern-action-rename:split)
 
   if !a:disable_default_mappings
-    call fern#mapping#nmap('R', '<Plug>(fern-action-rename)')
+    nmap <buffer><nowait> R <Plug>(fern-action-rename)
   endif
 endfunction
 

--- a/autoload/fern/scheme/file/mapping/system.vim
+++ b/autoload/fern/scheme/file/mapping/system.vim
@@ -4,7 +4,7 @@ function! fern#scheme#file#mapping#system#init(disable_default_mappings) abort
   nnoremap <buffer><silent> <Plug>(fern-action-open:system) :<C-u>call <SID>call('open_system')<CR>
 
   if !a:disable_default_mappings
-    call fern#mapping#nmap('x', '<Plug>(fern-action-open:system)')
+    nmap <buffer><nowait> x <Plug>(fern-action-open:system)
   endif
 endfunction
 

--- a/doc/fern-develop.txt
+++ b/doc/fern-develop.txt
@@ -188,20 +188,6 @@ like:
 	A |List| of globally available mapping names. 
 	A target mapping MUST exist under "fern#mapping#" namespace.
 
-Use the following functions to define default mappings
-
-					*fern#mapping#nmap()*
-					*fern#mapping#vmap()*
-fern#mapping#nmap({lhs}, {rhs})
-fern#mapping#vmap({lhs}, {rhs})
-	Define nmap/vmap from {lhs} to {rhs} when |hasmapto()| of {rhs}
-	returns 0 thus users can define an alternative mapping for {rhs}.
-	It defines mappings with |map-<buffer>| and |map-<nowait>|.
-
-	Example:
->
-	call fern#mapping#nmap('l', '<Plug>(fern-action-open-or-expand)')
-<
 
 =============================================================================
 SCHEME						*fern-develop-scheme*

--- a/doc/fern.txt
+++ b/doc/fern.txt
@@ -366,9 +366,6 @@ VARIABLE						*fern-variable*
 
 *g:fern#disable_default_mappings*
 	Set 1 to disable default mappings
-	Note that each default mappings are defined when |hasmapto()| returns
-	0, mean that defining an alternative mapping avoid corresponding
-	default mappings. See |fern-mapping| for detail.
 	Note that this variable does not affect mappings for actions.
 	See |fern-action-mappings| for more detail.
 	Default: 0
@@ -690,17 +687,6 @@ FernWindowSelectStatusLine		*hl-FernWindowSelectStatusLine*
 
 =============================================================================
 MAPPING							*fern-mapping*
-
-All built-in mappings are defined after |FileType| |autocmd| if |hasmapto()| of
-the corresponding mapping return 0. So users simply define alternative mappings
-to disable the default mappings in |FileType| autocmd like:
->
-	" The following disable default 'E' which is mapped to
-	" <Plug>(fern-action-open:side) in default by defining
-	" an alternative mapping 'v'
-	nmap <buffer><nowait> v <Plug>(fern-action-open:side)
-<
-Or use |g:fern#disable_default_mappings| to disable all default mappings.
 
 As described in |fern-action|, some mappings in fern are used as action.
 See |fern-action| for more detail.


### PR DESCRIPTION
#218 introduce #221 and I now think the original want (#212) does not fit on fern's mapping system thus revert it.