### PR TITLE
fix command option completion

### DIFF
--- a/autoload/fern/internal/command/reveal.vim
+++ b/autoload/fern/internal/command/reveal.vim
@@ -38,6 +38,9 @@ function! fern#internal#command#reveal#command(modes, fargs) abort
 endfunction
 
 function! fern#internal#command#reveal#complete(arglead, cmdline, cursorpos) abort
+  if a:arglead =~# '^-'
+    return fern#internal#complete#options(a:arglead, a:cmdline, a:cursorpos)
+  endif
   let helper = fern#helper#new()
   let fri = fern#fri#parse(bufname('%'))
   let scheme = helper.fern.scheme

--- a/autoload/fern/internal/complete.vim
+++ b/autoload/fern/internal/complete.vim
@@ -38,13 +38,13 @@ let s:options = {
       \}
 
 function! fern#internal#complete#opener(arglead, cmdline, cursorpos) abort
-  let pattern = '^' . a:arglead
+  let pattern = '\V\^' . escape(a:arglead, '\\')
   let candidates = map(copy(s:openers), { _, v -> printf('-opener=%s', v) })
   return filter(candidates, { _, v -> v =~# pattern })
 endfunction
 
 function! fern#internal#complete#options(arglead, cmdline, cursorpos) abort
-  let pattern = '^' . a:arglead
+  let pattern = '\V\^' . escape(a:arglead, '\\')
   let command = matchstr(a:cmdline, '^\w\+')
   let candidates = get(s:options, command, [])
   return filter(copy(candidates), { _, v -> v =~# pattern })

--- a/autoload/fern/internal/complete.vim
+++ b/autoload/fern/internal/complete.vim
@@ -25,11 +25,13 @@ let s:options = {
       \   '-reveal=',
       \   '-stay',
       \   '-toggle',
+      \   '-wait',
       \   '-width=',
       \ ],
-      \ 'FernFocus': [
+      \ 'FernDo': [
       \   '-drawer',
-      \ ]
+      \   '-stay',
+      \ ],
       \}
 
 function! fern#internal#complete#opener(arglead, cmdline, cursorpos) abort

--- a/autoload/fern/internal/complete.vim
+++ b/autoload/fern/internal/complete.vim
@@ -1,3 +1,5 @@
+let s:ESCAPE_PATTERN = '^$~.*[]\'
+
 let s:openers = [
       \ 'select',
       \ 'edit',
@@ -38,13 +40,13 @@ let s:options = {
       \}
 
 function! fern#internal#complete#opener(arglead, cmdline, cursorpos) abort
-  let pattern = '\V\^' . escape(a:arglead, '\\')
+  let pattern = '^' . escape(a:arglead, s:ESCAPE_PATTERN)
   let candidates = map(copy(s:openers), { _, v -> printf('-opener=%s', v) })
   return filter(candidates, { _, v -> v =~# pattern })
 endfunction
 
 function! fern#internal#complete#options(arglead, cmdline, cursorpos) abort
-  let pattern = '\V\^' . escape(a:arglead, '\\')
+  let pattern = '^' . escape(a:arglead, s:ESCAPE_PATTERN)
   let command = matchstr(a:cmdline, '^\w\+')
   let candidates = get(s:options, command, [])
   return filter(copy(candidates), { _, v -> v =~# pattern })

--- a/autoload/fern/internal/complete.vim
+++ b/autoload/fern/internal/complete.vim
@@ -32,6 +32,9 @@ let s:options = {
       \   '-drawer',
       \   '-stay',
       \ ],
+      \ 'FernReveal': [
+      \   '-wait',
+      \ ],
       \}
 
 function! fern#internal#complete#opener(arglead, cmdline, cursorpos) abort

--- a/test/fern/internal/complete.vimspec
+++ b/test/fern/internal/complete.vimspec
@@ -1,0 +1,140 @@
+Describe fern#internal#complete
+  Describe #opener()
+    It returns all openers
+      let arglead = '-opener='
+      let cmdline = 'Fern -opener='
+      let cursorpos = strlen(cmdline)
+      let want = [
+            \ '-opener=select',
+            \ '-opener=edit',
+            \ '-opener=edit/split',
+            \ '-opener=edit/vsplit',
+            \ '-opener=edit/tabedit',
+            \ '-opener=split',
+            \ '-opener=vsplit',
+            \ '-opener=tabedit',
+            \ '-opener=leftabove\ split',
+            \ '-opener=leftabove\ vsplit',
+            \ '-opener=rightbelow\ split',
+            \ '-opener=rightbelow\ vsplit',
+            \ '-opener=topleft\ split',
+            \ '-opener=topleft\ vsplit',
+            \ '-opener=botright\ split',
+            \ '-opener=botright\ vsplit',
+            \]
+      let got = fern#internal#complete#opener(arglead, cmdline, cursorpos)
+      Assert Equals(got, want)
+    End
+
+    It returns openers whose name starts with 'e'
+      let arglead = '-opener=e'
+      let cmdline = 'Fern -opener=e'
+      let cursorpos = strlen(cmdline)
+      let want = [
+            \ '-opener=edit',
+            \ '-opener=edit/split',
+            \ '-opener=edit/vsplit',
+            \ '-opener=edit/tabedit',
+            \]
+      let got = fern#internal#complete#opener(arglead, cmdline, cursorpos)
+      Assert Equals(got, want)
+    End
+
+    It returns openers whose name ends with backslash
+      let arglead = '-opener=leftabove\'
+      let cmdline = 'Fern -opener=leftabove\'
+      let cursorpos = strlen(cmdline)
+      let want = [
+            \ '-opener=leftabove\ split',
+            \ '-opener=leftabove\ vsplit',
+            \]
+      let got = fern#internal#complete#opener(arglead, cmdline, cursorpos)
+      Assert Equals(got, want)
+    End
+
+    It returns openers whose name ends with space
+      let arglead = '-opener=leftabove\ '
+      let cmdline = 'Fern -opener=leftabove\ '
+      let cursorpos = strlen(cmdline)
+      let want = [
+            \ '-opener=leftabove\ split',
+            \ '-opener=leftabove\ vsplit',
+            \]
+      let got = fern#internal#complete#opener(arglead, cmdline, cursorpos)
+      Assert Equals(got, want)
+    End
+
+    It returns no openers, if opener is unknown
+      let arglead = '-opener=x'
+      let cmdline = 'Fern -opener=x'
+      let cursorpos = strlen(cmdline)
+      let want = []
+      let got = fern#internal#complete#opener(arglead, cmdline, cursorpos)
+      Assert Equals(got, want)
+    End
+  End
+
+  Describe #options()
+    It returns all options of ':Fern'
+      let arglead = '-'
+      let cmdline = 'Fern -'
+      let cursorpos = strlen(cmdline)
+      let want = [
+            \ '-drawer',
+            \ '-keep',
+            \ '-opener=',
+            \ '-reveal=',
+            \ '-stay',
+            \ '-toggle',
+            \ '-wait',
+            \ '-width=',
+            \]
+      let got = fern#internal#complete#options(arglead, cmdline, cursorpos)
+      Assert Equals(got, want)
+    End
+
+    It returns all options of ':FernDo'
+      let arglead = '-'
+      let cmdline = 'FernDo -'
+      let cursorpos = strlen(cmdline)
+      let want = [
+            \ '-drawer',
+            \ '-stay',
+            \]
+      let got = fern#internal#complete#options(arglead, cmdline, cursorpos)
+      Assert Equals(got, want)
+    End
+
+    It returns all options of ':FernReveal'
+      let arglead = '-'
+      let cmdline = 'FernReveal -'
+      let cursorpos = strlen(cmdline)
+      let want = [
+            \ '-wait',
+            \]
+      let got = fern#internal#complete#options(arglead, cmdline, cursorpos)
+      Assert Equals(got, want)
+    End
+
+    It returns options of ':Fern' whose name starts with 'w'
+      let arglead = '-w'
+      let cmdline = 'Fern -w'
+      let cursorpos = strlen(cmdline)
+      let want = [
+            \ '-wait',
+            \ '-width=',
+            \]
+      let got = fern#internal#complete#options(arglead, cmdline, cursorpos)
+      Assert Equals(got, want)
+    End
+
+    It returns no options, if arglead is unknown
+      let arglead = '-xxx'
+      let cmdline = 'Fern -xxx'
+      let cursorpos = strlen(cmdline)
+      let want = []
+      let got = fern#internal#complete#options(arglead, cmdline, cursorpos)
+      Assert Equals(got, want)
+    End
+  End
+End

--- a/test/fern/internal/complete.vimspec
+++ b/test/fern/internal/complete.vimspec
@@ -72,6 +72,17 @@ Describe fern#internal#complete
       let got = fern#internal#complete#opener(arglead, cmdline, cursorpos)
       Assert Equals(got, want)
     End
+
+    It returns no openers, if arglead is invalid
+      let invalid_argleads = ['opener=', '^', '$', '.', '[o]']
+      for arglead in invalid_argleads
+        let cmdline = 'Fern ' . arglead
+        let cursorpos = strlen(cmdline)
+        let want = []
+        let got = fern#internal#complete#opener(arglead, cmdline, cursorpos)
+        Assert Equals(got, want, 'arglead pattern: ' . string(arglead))
+      endfor
+    End
   End
 
   Describe #options()
@@ -135,6 +146,17 @@ Describe fern#internal#complete
       let want = []
       let got = fern#internal#complete#options(arglead, cmdline, cursorpos)
       Assert Equals(got, want)
+    End
+
+    It returns no options, if arglead is invalid
+      let invalid_argleads = ['opener', '^', '$', '.', '[o]']
+      for arglead in invalid_argleads
+        let cmdline = 'Fern ' . arglead
+        let cursorpos = strlen(cmdline)
+        let want = []
+        let got = fern#internal#complete#options(arglead, cmdline, cursorpos)
+        Assert Equals(got, want, 'arglead pattern: ' . string(arglead))
+      endfor
     End
   End
 End


### PR DESCRIPTION
- Remove deprecated command completion.
- Add completion for `:FernDo` and `:FernReveal`.
- Fix completion pattern matching.
- Add tests.