### PR TITLE
Support Windows UNC path

### DIFF
--- a/autoload/fern/fri.vim
+++ b/autoload/fern/fri.vim
@@ -12,26 +12,28 @@ function! fern#fri#new(partial) abort
 endfunction
 
 function! fern#fri#parse(expr) abort
-  let remains = a:expr =~# '^fern:'
+  let is_fern = a:expr =~# '^fern:'
+  let remains = is_fern
         \ ? matchstr(a:expr, '.\{-}\ze\$\?$')
         \ : a:expr
   let [scheme, remains] = s:split1(remains, escape('://', s:PATTERN))
-  if empty(remains)
+  if remains is# v:null
     let remains = scheme
     let scheme = ''
   endif
   let [authority, remains] = s:split1(remains, escape('/', s:PATTERN))
-  if empty(remains)
+  if remains is# v:null
     let remains = authority
     let authority = ''
   endif
   let [path, remains] = s:split1(remains, escape(';', s:PATTERN))
-  if empty(remains)
+  if remains is# v:null
     let query = ''
-    let [path, fragment] = s:split1(path, escape('#', s:PATTERN))
+    let [path, remains] = s:split1(path, escape('#', s:PATTERN))
   else
-    let [query, fragment] = s:split1(remains, escape('#', s:PATTERN))
+    let [query, remains] = s:split1(remains, escape('#', s:PATTERN))
   endif
+  let fragment = remains isnot# v:null ? remains : ''
   return {
         \ 'scheme': scheme,
         \ 'authority': s:decode(authority),
@@ -135,7 +137,7 @@ endfunction
 function! s:split1(str, pattern) abort
   let [_, s, e] = matchstrpos(a:str, a:pattern)
   if s is# -1
-    return [a:str, '']
+    return [a:str, v:null]
   elseif s is# 0
     return ['', a:str[e :]]
   endif

--- a/autoload/fern/fri/from.vim
+++ b/autoload/fern/fri/from.vim
@@ -2,6 +2,9 @@ function! fern#fri#from#filepath(path) abort
   if !fern#internal#filepath#is_absolute(a:path)
     throw printf('The "path" must be an absolute path but "%s" has specfied', a:path)
   endif
+  if fern#internal#filepath#is_uncpath(a:path)
+    return s:from_uncpath(a:path)
+  endif
   let path = fern#internal#filepath#to_slash(a:path)
   return fern#fri#from#path(path)
 endfunction
@@ -18,4 +21,19 @@ function! fern#fri#from#path(path) abort
         \ 'scheme': 'file',
         \ 'path': path[1:],
         \})
+endfunction
+
+function! fern#fri#from#uncpath(path) abort
+  if !fern#internal#filepath#is_uncpath(a:path)
+    throw printf('The "path" must be an UNC path but "%s" has specfied', a:path)
+  endif
+  return s:from_uncpath(a:path)
+endfunction
+
+function! s:from_uncpath(path) abort
+  let terms = filter(split(a:path[2:], '\'), { -> !empty(v:val) })
+  let path = join(terms[1:], '/')
+  let fri = fern#fri#from#path('/' . path)
+  let fri.authority = terms[0]
+  return fri
 endfunction

--- a/autoload/fern/fri/to.vim
+++ b/autoload/fern/fri/to.vim
@@ -2,6 +2,9 @@ function! fern#fri#to#filepath(fri) abort
   if a:fri.scheme !=# 'file'
     throw printf('The "scheme" must be "file" but "%s" has specified', a:fri.scheme)
   endif
+  if !empty(a:fri.authority) && fern#internal#filepath#is_unc_compat()
+    return s:to_uncpath(a:fri)
+  endif
   let path = fern#fri#to#path(a:fri)
   let path = fern#internal#filepath#from_slash(path)
   return path
@@ -11,4 +14,24 @@ function! fern#fri#to#path(fri) abort
   let path = '/' . a:fri.path
   let path = fern#fri#decode(path)
   return path
+endfunction
+
+function! fern#fri#to#uncpath(fri) abort
+  if !fern#internal#filepath#is_unc_compat()
+    throw printf('The system does not support UNC path')
+  endif
+  if a:fri.scheme !=# 'file'
+    throw printf('The "scheme" must be "file" but "%s" has specified', a:fri.scheme)
+  endif
+  if empty(a:fri.authority)
+    throw printf('The "authority" must be non-empty')
+  endif
+  return s:to_uncpath(a:fri)
+endfunction
+
+function! s:to_uncpath(fri) abort
+  let path = fern#fri#decode(a:fri.path)
+  let path = fern#internal#filepath#from_slash(path)
+  let res = printf('\\%s\%s', a:fri.authority, path)
+  return res
 endfunction

--- a/autoload/fern/internal/command/do.vim
+++ b/autoload/fern/internal/command/do.vim
@@ -1,17 +1,18 @@
-function! fern#internal#command#do#command(mods, fargs) abort
+function! fern#internal#command#do#command(mods, qargs) abort
   let winid_saved = win_getid()
   try
-    let stay = fern#internal#args#pop(a:fargs, 'stay', v:false)
-    let drawer = fern#internal#args#pop(a:fargs, 'drawer', v:false)
+    let fargs = fern#internal#args#split(a:qargs)
+    let stay = fern#internal#args#pop(fargs, 'stay', v:false)
+    let drawer = fern#internal#args#pop(fargs, 'drawer', v:false)
 
-    if len(a:fargs) is# 0
+    if len(fargs) is# 0
           \ || type(stay) isnot# v:t_bool
           \ || type(drawer) isnot# v:t_bool
       throw 'Usage: FernDo {expr...} [-drawer] [-stay]'
     endif
 
     " Does all options are handled?
-    call fern#internal#args#throw_if_dirty(a:fargs)
+    call fern#internal#args#throw_if_dirty(fargs)
 
     let found = fern#internal#window#find(
           \ funcref('s:predicator', [drawer]),
@@ -21,7 +22,7 @@ function! fern#internal#command#do#command(mods, fargs) abort
       return
     endif
     call win_gotoid(win_getid(found))
-    execute join([a:mods] + a:fargs, ' ')
+    execute join([a:mods] + fargs, ' ')
   catch
     echohl ErrorMsg
     echo v:exception

--- a/autoload/fern/internal/command/fern.vim
+++ b/autoload/fern/internal/command/fern.vim
@@ -1,25 +1,26 @@
 let s:Promise = vital#fern#import('Async.Promise')
 let s:drawer_opener = 'topleft vsplit'
 
-function! fern#internal#command#fern#command(mods, fargs) abort
+function! fern#internal#command#fern#command(mods, qargs) abort
   try
-    let stay = fern#internal#args#pop(a:fargs, 'stay', v:false)
-    let wait = fern#internal#args#pop(a:fargs, 'wait', v:false)
-    let reveal = fern#internal#args#pop(a:fargs, 'reveal', '')
-    let drawer = fern#internal#args#pop(a:fargs, 'drawer', v:false)
+    let fargs = fern#internal#args#split(a:qargs)
+    let stay = fern#internal#args#pop(fargs, 'stay', v:false)
+    let wait = fern#internal#args#pop(fargs, 'wait', v:false)
+    let reveal = fern#internal#args#pop(fargs, 'reveal', '')
+    let drawer = fern#internal#args#pop(fargs, 'drawer', v:false)
     if drawer
       let opener = s:drawer_opener
-      let width = fern#internal#args#pop(a:fargs, 'width', '')
-      let keep = fern#internal#args#pop(a:fargs, 'keep', v:false)
-      let toggle = fern#internal#args#pop(a:fargs, 'toggle', v:false)
+      let width = fern#internal#args#pop(fargs, 'width', '')
+      let keep = fern#internal#args#pop(fargs, 'keep', v:false)
+      let toggle = fern#internal#args#pop(fargs, 'toggle', v:false)
     else
-      let opener = fern#internal#args#pop(a:fargs, 'opener', g:fern#opener)
+      let opener = fern#internal#args#pop(fargs, 'opener', g:fern#opener)
       let width = ''
       let keep = v:false
       let toggle = v:false
     endif
 
-    if len(a:fargs) isnot# 1
+    if len(fargs) isnot# 1
           \ || type(stay) isnot# v:t_bool
           \ || type(wait) isnot# v:t_bool
           \ || type(reveal) isnot# v:t_string
@@ -36,7 +37,7 @@ function! fern#internal#command#fern#command(mods, fargs) abort
     endif
 
     " Does all options are handled?
-    call fern#internal#args#throw_if_dirty(a:fargs)
+    call fern#internal#args#throw_if_dirty(fargs)
 
     " Force project drawer style when
     " - The current buffer is project drawer style fern
@@ -46,7 +47,7 @@ function! fern#internal#command#fern#command(mods, fargs) abort
       let opener = s:drawer_opener
     endif
 
-    let expr = fern#util#expand(a:fargs[0])
+    let expr = fern#util#expand(fargs[0])
     let path = fern#fri#format(
           \ expr =~# '^[^:]\+://'
           \   ? fern#fri#parse(expr)

--- a/autoload/fern/internal/filepath.vim
+++ b/autoload/fern/internal/filepath.vim
@@ -30,6 +30,14 @@ function! fern#internal#filepath#is_absolute(path) abort
         \ : s:is_absolute_unix(a:path)
 endfunction
 
+function! fern#internal#filepath#is_unc_compat() abort
+  return g:fern#internal#filepath#is_windows
+endfunction
+
+function! fern#internal#filepath#is_uncpath(path) abort
+  return g:fern#internal#filepath#is_windows && s:is_uncpath(a:path)
+endfunction
+
 function! fern#internal#filepath#join(paths) abort
   let paths = map(
         \ copy(a:paths),
@@ -59,8 +67,12 @@ function! s:from_slash_windows(path) abort
   return path[:2] =~# '^\w:$' ? path . '\' : path
 endfunction
 
+function! s:is_uncpath(path) abort
+  return a:path =~# '^\\\\[^\\]\+'
+endfunction
+
 function! s:is_absolute_windows(path) abort
-  return a:path ==# '' || a:path[:2] =~# '^\w:\\$'
+  return a:path ==# '' || a:path[:2] =~# '^\w:\\$' || s:is_uncpath(a:path)
 endfunction
 
 function! s:is_absolute_unix(path) abort

--- a/autoload/fern/scheme/file/complete.vim
+++ b/autoload/fern/scheme/file/complete.vim
@@ -1,45 +1,39 @@
+let s:PATHSEP = fnamemodify('.', ':p')[-1 :]
+
 function! fern#scheme#file#complete#url(arglead, cmdline, cursorpos) abort
-  let path = '/' . fern#fri#parse(a:arglead).path
-  let path = fern#internal#filepath#to_slash(path)
-  let suffix = a:arglead =~# '/$' ? '/' : ''
-  let rs = getcompletion(fern#internal#filepath#from_slash(path) . suffix, 'dir')
-  call map(rs, { -> fern#internal#filepath#to_slash(v:val) })
-  call map(rs, { -> s:to_fri(v:val) })
+  let suffix = a:arglead =~# '/$' ? s:PATHSEP : ''
+  let fpath = fern#fri#to#filepath(fern#fri#parse(a:arglead))
+  let rs = s:complete_filepath(fpath . suffix, 'dir')
+  call map(rs, { -> fern#fri#from#filepath(v:val) })
+  call map(rs, { -> fern#fri#format(v:val) })
   return rs
 endfunction
 
 function! fern#scheme#file#complete#reveal(arglead, cmdline, cursorpos) abort
-  let base = '/' . fern#fri#parse(matchstr(a:cmdline, '\<file:///\S*')).path
+  let base_url = matchstr(a:cmdline, '\<file://\S*')
+  let fbase = fern#fri#to#filepath(fern#fri#parse(base_url))
   let path = matchstr(a:arglead, '^-reveal=\zs.*')
-  let suffix = matchstr(path, '/$')
-  let rs = s:complete_reveal(path, base, suffix)
+  let suffix = path =~# '/$' ? s:PATHSEP : ''
+  let fpath = path ==# '' ? '' : fern#internal#filepath#from_slash(path)
+  let rs = s:complete_reveal(fpath . suffix, fbase)
+  call map(rs, { -> fern#internal#filepath#to_slash(v:val) })
   call map(rs, { -> printf('-reveal=%s', v:val) })
   return rs
 endfunction
 
 function! fern#scheme#file#complete#filepath(arglead, cmdline, cursorpos) abort
-  return map(getcompletion(a:arglead, 'dir'), { -> escape(v:val, ' ') })
-endfunction
-
-function! fern#scheme#file#complete#filepath_reveal(arglead, cmdline, cursorpos) abort
-  let base = fern#internal#filepath#to_slash(s:get_basepath(a:cmdline))
-  let path = matchstr(a:arglead, '^-reveal=\zs.*')
-  let suffix = matchstr(path, '[/\\]$')
-  let path = path ==# '' ? '' : fern#internal#filepath#to_slash(path)
-  let rs = s:complete_reveal(path, base, suffix)
-  call map(rs, { -> v:val ==# '' ? '' : fern#internal#filepath#from_slash(v:val) })
-  call map(rs, { -> printf('-reveal=%s', escape(v:val, ' ')) })
+  let rs = s:complete_filepath(a:arglead, 'dir')
+  call map(rs, { -> escape(v:val, ' ') })
   return rs
 endfunction
 
-function! s:to_fri(path) abort
-  return fern#fri#format({
-        \ 'scheme': 'file',
-        \ 'authority': '',
-        \ 'path': a:path[1:],
-        \ 'query': {},
-        \ 'fragment': '',
-        \})
+function! fern#scheme#file#complete#filepath_reveal(arglead, cmdline, cursorpos) abort
+  let fbase = s:get_basepath(a:cmdline)
+  let fpath = matchstr(a:arglead, '^-reveal=\zs.*')
+  let rs = s:complete_reveal(fpath, fbase)
+  call map(rs, { -> substitute(v:val, '[/\\]$', '', '') })
+  call map(rs, { -> printf('-reveal=%s', escape(v:val, ' ')) })
+  return rs
 endfunction
 
 function! s:get_basepath(cmdline) abort
@@ -50,20 +44,61 @@ function! s:get_basepath(cmdline) abort
   return fnamemodify(base, ':p')
 endfunction
 
-function! s:complete_reveal(path, base, suffix) abort
-  let [path, base, suffix] = [a:path, a:base, a:suffix]
-  if path ==# ''
-    let path = a:base
-    let suffix = '/'
-  elseif path[:0] ==# '/'
-    let base = ''
+function! s:complete_filepath(path, type) abort
+  if fern#internal#filepath#is_uncpath(a:path)
+    let fri = fern#fri#from#filepath(a:path)
+    if fri.path ==# '' || fri.path !~# '/' && a:path !~# '[/\\]$'
+      return s:windows_share_nodes(fri)
+    endif
+  endif
+  return getcompletion(a:path, a:type)
+endfunction
+
+function! s:complete_reveal(fpath, fbase) abort
+  let [fpath, fbase] = [a:fpath, a:fbase]
+  if fpath !=# '' && fern#internal#filepath#is_absolute(fpath)
+    return s:complete_filepath(fpath, 'file')
+  endif
+  if fpath ==# ''
+    if fbase !~# '[/\\]$'
+      let fbase .= s:PATHSEP
+    endif
+    let base = fern#internal#filepath#to_slash(fbase)
+    let rs = s:complete_filepath(fbase, 'file')
+    call map(rs, { -> fern#internal#filepath#to_slash(v:val) })
   else
-    let path = fern#internal#path#absolute(path, a:base)
+    let suffix = matchstr(fpath, '[/\\]$')
+    let path = fern#internal#filepath#to_slash(fpath)
+    let fri = fern#fri#from#filepath(fbase)
+    let base = '/' . fri.path
+    let fri.path = fern#internal#path#absolute(path, base)[1 :]
+    let rs = s:complete_filepath(fern#fri#to#filepath(fri) . suffix, 'file')
+    call map(rs, { -> '/' . fern#fri#from#filepath(v:val).path })
   endif
-  let rs = getcompletion(fern#internal#filepath#from_slash(path) . suffix, 'file')
-  call map(rs, { -> fern#internal#filepath#to_slash(v:val) })
-  if base !=# ''
-    call map(rs, { -> fern#internal#path#relative(v:val, base) })
-  endif
+  call map(rs, { -> fern#internal#path#relative(v:val, base) })
+  call map(rs, { -> v:val ==# '' ? '' : fern#internal#filepath#from_slash(v:val) })
   return rs
 endfunction
+
+if has('win32')
+  let s:Promise = vital#fern#import('Async.Promise')
+  let s:CancellationToken = vital#fern#import('Async.CancellationToken')
+
+  function! s:windows_share_nodes(fri) abort
+    let waiter = fern#scheme#file#util#list_shares(
+          \ s:CancellationToken.none, a:fri.authority)
+    let [rs, err] = s:Promise.wait(waiter, {'timeout': 2000})
+    if err isnot# v:null
+      return []
+    endif
+    if a:fri.path !=# ''
+      let path = tolower(a:fri.path)
+      let plen = strlen(path)
+      call filter(rs, { -> tolower(v:val[: plen]) ==# path })
+    endif
+    call map(rs, { -> extend(deepcopy(a:fri), {'path': v:val}) })
+    call map(rs, { -> fern#fri#to#uncpath(v:val) . '\' })
+    call filter(rs, { -> getftype(v:val) ==# 'dir' })
+    return rs
+  endfunction
+endif

--- a/autoload/fern/scheme/file/util.vim
+++ b/autoload/fern/scheme/file/util.vim
@@ -63,4 +63,14 @@ if s:is_windows
           \.then(s:AsyncLambda.map_f({ v -> v:val[:1] . '\' }))
           \.finally({ -> Profile() })
   endfunction
+
+  function! fern#scheme#file#util#list_shares(token, host) abort
+    let l:Profile = fern#profile#start('fern#scheme#file#util#list_shares')
+    return s:Process.start(['wmic', printf('/node:%s', a:host), 'share', 'get', 'name'], { 'token': a:token, 'reject_on_failure': 1 })
+          \.catch({ v -> s:Promise.reject(join(v.stderr, "\n")) })
+          \.then({ v -> v.stdout })
+          \.then(s:AsyncLambda.filter_f({ v, i -> i > 0 && v =~# '^\w' }))
+          \.then(s:AsyncLambda.map_f({ v -> substitute(v, ' .*$', '', '') }))
+          \.finally({ -> Profile() })
+  endfunction
 endif

--- a/plugin/fern.vim
+++ b/plugin/fern.vim
@@ -7,12 +7,12 @@ let g:fern_loaded = 1 " Obsolete: For backward compatibility
 command! -bar -nargs=*
       \ -complete=customlist,fern#internal#command#fern#complete
       \ Fern
-      \ call fern#internal#command#fern#command(<q-mods>, [<f-args>])
+      \ call fern#internal#command#fern#command(<q-mods>, <q-args>)
 
 command! -bar -nargs=*
       \ -complete=customlist,fern#internal#command#do#complete
       \ FernDo
-      \ call fern#internal#command#do#command(<q-mods>, [<f-args>])
+      \ call fern#internal#command#do#command(<q-mods>, <q-args>)
 
 function! s:BufReadCmd() abort
   if exists('b:fern')

--- a/test/fern/fri.vimspec
+++ b/test/fern/fri.vimspec
@@ -57,6 +57,114 @@ Describe fern#fri
   End
 
   Describe #parse()
+    It returns FRI for 'file://'
+      let expr = 'file://'
+      let want = {
+            \ 'scheme': 'file',
+            \ 'authority': '',
+            \ 'path': '',
+            \ 'query': {},
+            \ 'fragment': '',
+            \}
+      Assert Equals(fern#fri#parse(expr), want)
+    End
+
+    It returns FRI for 'file:///'
+      let expr = 'file:///'
+      let want = {
+            \ 'scheme': 'file',
+            \ 'authority': '',
+            \ 'path': '',
+            \ 'query': {},
+            \ 'fragment': '',
+            \}
+      Assert Equals(fern#fri#parse(expr), want)
+    End
+
+    It returns FRI for 'file:///;'
+      let expr = 'file:///;'
+      let want = {
+            \ 'scheme': 'file',
+            \ 'authority': '',
+            \ 'path': '',
+            \ 'query': {},
+            \ 'fragment': '',
+            \}
+      Assert Equals(fern#fri#parse(expr), want)
+    End
+
+    It returns FRI for 'file:///#'
+      let expr = 'file:///#'
+      let want = {
+            \ 'scheme': 'file',
+            \ 'authority': '',
+            \ 'path': '',
+            \ 'query': {},
+            \ 'fragment': '',
+            \}
+      Assert Equals(fern#fri#parse(expr), want)
+    End
+
+    It returns FRI for 'file:///;#'
+      let expr = 'file:///;#'
+      let want = {
+            \ 'scheme': 'file',
+            \ 'authority': '',
+            \ 'path': '',
+            \ 'query': {},
+            \ 'fragment': '',
+            \}
+      Assert Equals(fern#fri#parse(expr), want)
+    End
+
+    It returns FRI for 'file://localhost/'
+      let expr = 'file://localhost/'
+      let want = {
+            \ 'scheme': 'file',
+            \ 'authority': 'localhost',
+            \ 'path': '',
+            \ 'query': {},
+            \ 'fragment': '',
+            \}
+      Assert Equals(fern#fri#parse(expr), want)
+    End
+
+    It returns FRI for 'file://localhost/;'
+      let expr = 'file://localhost/;'
+      let want = {
+            \ 'scheme': 'file',
+            \ 'authority': 'localhost',
+            \ 'path': '',
+            \ 'query': {},
+            \ 'fragment': '',
+            \}
+      Assert Equals(fern#fri#parse(expr), want)
+    End
+
+    It returns FRI for 'file://localhost/#'
+      let expr = 'file://localhost/#'
+      let want = {
+            \ 'scheme': 'file',
+            \ 'authority': 'localhost',
+            \ 'path': '',
+            \ 'query': {},
+            \ 'fragment': '',
+            \}
+      Assert Equals(fern#fri#parse(expr), want)
+    End
+
+    It returns FRI for 'file://localhost/;#'
+      let expr = 'file://localhost/;#'
+      let want = {
+            \ 'scheme': 'file',
+            \ 'authority': 'localhost',
+            \ 'path': '',
+            \ 'query': {},
+            \ 'fragment': '',
+            \}
+      Assert Equals(fern#fri#parse(expr), want)
+    End
+
     It returns FRI for 'file:///foo/bar'
       let expr = 'file:///foo/bar'
       let want = {
@@ -65,6 +173,94 @@ Describe fern#fri
             \ 'path': 'foo/bar',
             \ 'query': {},
             \ 'fragment': '',
+            \}
+      Assert Equals(fern#fri#parse(expr), want)
+    End
+
+    It returns FRI for 'file:///foo/bar;'
+      let expr = 'file:///foo/bar;'
+      let want = {
+            \ 'scheme': 'file',
+            \ 'authority': '',
+            \ 'path': 'foo/bar',
+            \ 'query': {},
+            \ 'fragment': '',
+            \}
+      Assert Equals(fern#fri#parse(expr), want)
+    End
+
+    It returns FRI for 'file:///foo/bar#'
+      let expr = 'file:///foo/bar#'
+      let want = {
+            \ 'scheme': 'file',
+            \ 'authority': '',
+            \ 'path': 'foo/bar',
+            \ 'query': {},
+            \ 'fragment': '',
+            \}
+      Assert Equals(fern#fri#parse(expr), want)
+    End
+
+    It returns FRI for 'file:///foo/bar;#'
+      let expr = 'file:///foo/bar;#'
+      let want = {
+            \ 'scheme': 'file',
+            \ 'authority': '',
+            \ 'path': 'foo/bar',
+            \ 'query': {},
+            \ 'fragment': '',
+            \}
+      Assert Equals(fern#fri#parse(expr), want)
+    End
+
+    It returns FRI for 'file:///;drawer'
+      let expr = 'file:///;drawer'
+      let want = {
+            \ 'scheme': 'file',
+            \ 'authority': '',
+            \ 'path': '',
+            \ 'query': {
+            \   'drawer': v:true,
+            \ },
+            \ 'fragment': '',
+            \}
+      Assert Equals(fern#fri#parse(expr), want)
+    End
+
+    It returns FRI for 'file:///;drawer#'
+      let expr = 'file:///;drawer#'
+      let want = {
+            \ 'scheme': 'file',
+            \ 'authority': '',
+            \ 'path': '',
+            \ 'query': {
+            \   'drawer': v:true,
+            \ },
+            \ 'fragment': '',
+            \}
+      Assert Equals(fern#fri#parse(expr), want)
+    End
+
+    It returns FRI for 'file:///#fragment'
+      let expr = 'file:///#fragment'
+      let want = {
+            \ 'scheme': 'file',
+            \ 'authority': '',
+            \ 'path': '',
+            \ 'query': {},
+            \ 'fragment': 'fragment',
+            \}
+      Assert Equals(fern#fri#parse(expr), want)
+    End
+
+    It returns FRI for 'file:///;#fragment'
+      let expr = 'file:///;#fragment'
+      let want = {
+            \ 'scheme': 'file',
+            \ 'authority': '',
+            \ 'path': '',
+            \ 'query': {},
+            \ 'fragment': 'fragment',
             \}
       Assert Equals(fern#fri#parse(expr), want)
     End

--- a/test/fern/fri/from.vimspec
+++ b/test/fern/fri/from.vimspec
@@ -166,6 +166,30 @@ Describe fern#fri#from
               \}
         Assert Equals(fern#fri#from#filepath(expr), want)
       End
+
+      It returns FRI from \\localhost
+        let expr = '\\localhost'
+        let want = {
+              \ 'scheme': 'file',
+              \ 'authority': 'localhost',
+              \ 'path': '',
+              \ 'query': {},
+              \ 'fragment': '',
+              \}
+        Assert Equals(fern#fri#from#uncpath(expr), want)
+      End
+
+      It returns FRI from \\localhost\C$\foo\bar
+        let expr = '\\localhost\C$\foo\bar'
+        let want = {
+              \ 'scheme': 'file',
+              \ 'authority': 'localhost',
+              \ 'path': 'C$/foo/bar',
+              \ 'query': {},
+              \ 'fragment': '',
+              \}
+        Assert Equals(fern#fri#from#uncpath(expr), want)
+      End
     End
 
     Context Unix
@@ -259,6 +283,88 @@ Describe fern#fri#from
               \ 'fragment': '',
               \}
         Assert Equals(fern#fri#from#filepath(expr), want)
+      End
+
+      It throws an error if the path is an UNC path (\\localhost\foo\bar)
+        Throws /The "path" must be an absolute path/ fern#fri#from#filepath('\\localhost\foo\bar')
+      End
+    End
+  End
+
+  Describe #uncpath()
+    Context Windows
+      Before
+        let g:fern#internal#filepath#is_windows = 1
+      End
+
+      It throws an error if the path is not an UNC path
+        Throws /The "path" must be an UNC path/ fern#fri#from#uncpath('C:\foo\bar')
+      End
+
+      It returns FRI from \\localhost
+        let expr = '\\localhost'
+        let want = {
+              \ 'scheme': 'file',
+              \ 'authority': 'localhost',
+              \ 'path': '',
+              \ 'query': {},
+              \ 'fragment': '',
+              \}
+        Assert Equals(fern#fri#from#uncpath(expr), want)
+      End
+
+      It returns FRI from \\localhost\C$\foo\bar
+        let expr = '\\localhost\C$\foo\bar'
+        let want = {
+              \ 'scheme': 'file',
+              \ 'authority': 'localhost',
+              \ 'path': 'C$/foo/bar',
+              \ 'query': {},
+              \ 'fragment': '',
+              \}
+        Assert Equals(fern#fri#from#uncpath(expr), want)
+      End
+
+      It returns FRI from \\localhost\C$\foo\bar#a&b=c
+        let expr = '\\localhost\C$\foo\bar#a&b=c'
+        let want = {
+              \ 'scheme': 'file',
+              \ 'authority': 'localhost',
+              \ 'path': 'C$/foo/bar%23a&b=c',
+              \ 'query': {},
+              \ 'fragment': '',
+              \}
+        Assert Equals(fern#fri#from#uncpath(expr), want)
+      End
+
+      It returns FRI from \\localhost\C$\foo\bar#foo\bar\hoge
+        let expr = '\\localhost\C$\foo\bar#foo\bar\hoge'
+        let want = {
+              \ 'scheme': 'file',
+              \ 'authority': 'localhost',
+              \ 'path': 'C$/foo/bar%23foo/bar/hoge',
+              \ 'query': {},
+              \ 'fragment': '',
+              \}
+        Assert Equals(fern#fri#from#uncpath(expr), want)
+      End
+    End
+
+    Context Unix
+      Before
+        let g:fern#internal#filepath#is_windows = 0
+      End
+
+      It throws an error if the path is not an UNC path
+        Throws /The "path" must be an UNC path/ fern#fri#from#uncpath('/foo/bar')
+      End
+
+      It throws an error if the path is an UNC like path (//localhost/foo/bar)
+        Throws /The "path" must be an UNC path/ fern#fri#from#uncpath('//localhost/foo/bar')
+      End
+
+      It throws an error if the path is an UNC path (\\localhost\foo\bar)
+        Throws /The "path" must be an UNC path/ fern#fri#from#uncpath('\\localhost\foo\bar')
       End
     End
   End

--- a/test/fern/fri/to.vimspec
+++ b/test/fern/fri/to.vimspec
@@ -1,0 +1,382 @@
+Describe fern#fri#to
+  Before all
+    let fern_internal_filepath_is_windows = g:fern#internal#filepath#is_windows
+  End
+
+  After all
+    let g:fern#internal#filepath#is_windows = fern_internal_filepath_is_windows
+  End
+
+  Describe #path()
+    It returns path /foo/bar
+      let expr = {
+            \ 'scheme': 'file',
+            \ 'authority': '',
+            \ 'path': 'foo/bar',
+            \ 'query': {},
+            \ 'fragment': '',
+            \}
+      let want = '/foo/bar'
+      Assert Equals(fern#fri#to#path(expr), want)
+    End
+
+    It returns path /foo/bar/% (percent character)
+      let expr = {
+            \ 'scheme': 'file',
+            \ 'authority': '',
+            \ 'path': 'foo/bar/%25',
+            \ 'query': {},
+            \ 'fragment': '',
+            \}
+      let want = '/foo/bar/%'
+      Assert Equals(fern#fri#to#path(expr), want)
+    End
+
+    It returns path /foo/bar/<>|?* (unusable characters)
+      let expr = {
+            \ 'scheme': 'file',
+            \ 'authority': '',
+            \ 'path': 'foo/bar/%3C%3E%7C%3F%2A',
+            \ 'query': {},
+            \ 'fragment': '',
+            \}
+      let want = '/foo/bar/<>|?*'
+      Assert Equals(fern#fri#to#path(expr), want)
+    End
+
+    It returns path /foo/bar/#[];  (non pchar)
+      let expr = {
+            \ 'scheme': 'file',
+            \ 'authority': '',
+            \ 'path': 'foo/bar/%23%5B%5D%3B%20',
+            \ 'query': {},
+            \ 'fragment': '',
+            \}
+      let want = '/foo/bar/#[]; '
+      Assert Equals(fern#fri#to#path(expr), want)
+    End
+  End
+
+  Describe #filepath()
+    Context Windows
+      Before
+        let g:fern#internal#filepath#is_windows = 1
+      End
+
+      It throws an error if the FRI scheme is not "file"
+        let expr = {
+              \ 'scheme': 'foo',
+              \ 'authority': '',
+              \ 'path': 'C:',
+              \ 'query': {},
+              \ 'fragment': '',
+              \}
+        Throws /The "scheme" must be "file"/ fern#fri#to#filepath(expr)
+      End
+
+      It returns filepath C:\
+        let expr = {
+              \ 'scheme': 'file',
+              \ 'authority': '',
+              \ 'path': 'C:',
+              \ 'query': {},
+              \ 'fragment': '',
+              \}
+        let want = 'C:\'
+        Assert Equals(fern#fri#to#filepath(expr), want)
+      End
+
+      It returns filepath C:\foo\bar
+        let expr = {
+              \ 'scheme': 'file',
+              \ 'authority': '',
+              \ 'path': 'C:/foo/bar',
+              \ 'query': {},
+              \ 'fragment': '',
+              \}
+        let want = 'C:\foo\bar'
+        Assert Equals(fern#fri#to#filepath(expr), want)
+      End
+
+      It returns filepath C:\foo\bar?a&b=c
+        let expr = {
+              \ 'scheme': 'file',
+              \ 'authority': '',
+              \ 'path': 'C:/foo/bar%3Fa&b=c',
+              \ 'query': {},
+              \ 'fragment': '',
+              \}
+        let want = 'C:\foo\bar?a&b=c'
+        Assert Equals(fern#fri#to#filepath(expr), want)
+      End
+
+      It returns filepath C:\foo\bar;a&b=c
+        let expr = {
+              \ 'scheme': 'file',
+              \ 'authority': '',
+              \ 'path': 'C:/foo/bar%3Ba&b=c',
+              \ 'query': {},
+              \ 'fragment': '',
+              \}
+        let want = 'C:\foo\bar;a&b=c'
+        Assert Equals(fern#fri#to#filepath(expr), want)
+      End
+
+      It returns filepath C:\foo\bar#foo\bar\hoge
+        let expr = {
+              \ 'scheme': 'file',
+              \ 'authority': '',
+              \ 'path': 'C:/foo/bar%23foo/bar/hoge',
+              \ 'query': {},
+              \ 'fragment': '',
+              \}
+        let want = 'C:\foo\bar#foo\bar\hoge'
+        Assert Equals(fern#fri#to#filepath(expr), want)
+      End
+
+      It returns filepath C:\foo\bar?a&b=c#foo\bar\hoge
+        let expr = {
+              \ 'scheme': 'file',
+              \ 'authority': '',
+              \ 'path': 'C:/foo/bar%3Fa&b=c%23foo/bar/hoge',
+              \ 'query': {},
+              \ 'fragment': '',
+              \}
+        let want = 'C:\foo\bar?a&b=c#foo\bar\hoge'
+        Assert Equals(fern#fri#to#filepath(expr), want)
+      End
+
+      It returns filepath C:\foo\bar;a&b=c#foo\bar\hoge
+        let expr = {
+              \ 'scheme': 'file',
+              \ 'authority': '',
+              \ 'path': 'C:/foo/bar%3Ba&b=c%23foo/bar/hoge',
+              \ 'query': {},
+              \ 'fragment': '',
+              \}
+        let want = 'C:\foo\bar;a&b=c#foo\bar\hoge'
+        Assert Equals(fern#fri#to#filepath(expr), want)
+      End
+
+      It returns filepath \\localhost\
+        let expr = {
+              \ 'scheme': 'file',
+              \ 'authority': 'localhost',
+              \ 'path': '',
+              \ 'query': {},
+              \ 'fragment': '',
+              \}
+        let want = '\\localhost\'
+        Assert Equals(fern#fri#to#uncpath(expr), want)
+      End
+
+      It returns filepath \\localhost\C$\foo\bar
+        let expr = {
+              \ 'scheme': 'file',
+              \ 'authority': 'localhost',
+              \ 'path': 'C$/foo/bar',
+              \ 'query': {},
+              \ 'fragment': '',
+              \}
+        let want = '\\localhost\C$\foo\bar'
+        Assert Equals(fern#fri#to#uncpath(expr), want)
+      End
+    End
+
+    Context Unix
+      Before
+        let g:fern#internal#filepath#is_windows = 0
+      End
+
+      It throws an error if the FRI scheme is not "file"
+        let expr = {
+              \ 'scheme': 'foo',
+              \ 'authority': '',
+              \ 'path': '',
+              \ 'query': {},
+              \ 'fragment': '',
+              \}
+        Throws /The "scheme" must be "file"/ fern#fri#to#filepath(expr)
+      End
+
+      It returns filepath /
+        let expr = {
+              \ 'scheme': 'file',
+              \ 'authority': '',
+              \ 'path': '',
+              \ 'query': {},
+              \ 'fragment': '',
+              \}
+        let want = '/'
+        Assert Equals(fern#fri#to#filepath(expr), want)
+      End
+
+      It returns filepath /foo/bar
+        let expr = {
+              \ 'scheme': 'file',
+              \ 'authority': '',
+              \ 'path': 'foo/bar',
+              \ 'query': {},
+              \ 'fragment': '',
+              \}
+        let want = '/foo/bar'
+        Assert Equals(fern#fri#to#filepath(expr), want)
+      End
+
+      It returns filepath /foo/bar?a&b=c
+        let expr = {
+              \ 'scheme': 'file',
+              \ 'authority': '',
+              \ 'path': 'foo/bar%3Fa&b=c',
+              \ 'query': {},
+              \ 'fragment': '',
+              \}
+        let want = '/foo/bar?a&b=c'
+        Assert Equals(fern#fri#to#filepath(expr), want)
+      End
+
+      It returns filepath /foo/bar;a&b=c
+        let expr = {
+              \ 'scheme': 'file',
+              \ 'authority': '',
+              \ 'path': 'foo/bar%3Ba&b=c',
+              \ 'query': {},
+              \ 'fragment': '',
+              \}
+        let want = '/foo/bar;a&b=c'
+        Assert Equals(fern#fri#to#filepath(expr), want)
+      End
+
+      It returns filepath /foo/bar#foo/bar/hoge
+        let expr = {
+              \ 'scheme': 'file',
+              \ 'authority': '',
+              \ 'path': 'foo/bar%23foo/bar/hoge',
+              \ 'query': {},
+              \ 'fragment': '',
+              \}
+        let want = '/foo/bar#foo/bar/hoge'
+        Assert Equals(fern#fri#to#filepath(expr), want)
+      End
+
+      It returns filepath /foo/bar?a&b=c#foo/bar/hoge
+        let expr = {
+              \ 'scheme': 'file',
+              \ 'authority': '',
+              \ 'path': 'foo/bar%3Fa&b=c%23foo/bar/hoge',
+              \ 'query': {},
+              \ 'fragment': '',
+              \}
+        let want = '/foo/bar?a&b=c#foo/bar/hoge'
+        Assert Equals(fern#fri#to#filepath(expr), want)
+      End
+
+      It returns filepath /foo/bar;a&b=c#foo/bar/hoge
+        let expr = {
+              \ 'scheme': 'file',
+              \ 'authority': '',
+              \ 'path': 'foo/bar%3Ba&b=c%23foo/bar/hoge',
+              \ 'query': {},
+              \ 'fragment': '',
+              \}
+        let want = '/foo/bar;a&b=c#foo/bar/hoge'
+        Assert Equals(fern#fri#to#filepath(expr), want)
+      End
+    End
+  End
+
+  Describe #uncpath()
+    Context Windows
+      Before
+        let g:fern#internal#filepath#is_windows = 1
+      End
+
+      It throws an error if the FRI scheme is not "file"
+        let expr = {
+              \ 'scheme': 'foo',
+              \ 'authority': 'localhost',
+              \ 'path': '',
+              \ 'query': {},
+              \ 'fragment': '',
+              \}
+        Throws /The "scheme" must be "file"/ fern#fri#to#uncpath(expr)
+      End
+
+      It throws an error if the FRI authority is empty
+        let expr = {
+              \ 'scheme': 'file',
+              \ 'authority': '',
+              \ 'path': '',
+              \ 'query': {},
+              \ 'fragment': '',
+              \}
+        Throws /The "authority" must be non-empty/ fern#fri#to#uncpath(expr)
+      End
+
+      It returns uncpath \\localhost
+        let expr = {
+              \ 'scheme': 'file',
+              \ 'authority': 'localhost',
+              \ 'path': '',
+              \ 'query': {},
+              \ 'fragment': '',
+              \}
+        let want = '\\localhost\'
+        Assert Equals(fern#fri#to#uncpath(expr), want)
+      End
+
+      It returns uncpath \\localhost\C$\foo\bar
+        let expr = {
+              \ 'scheme': 'file',
+              \ 'authority': 'localhost',
+              \ 'path': 'C$/foo/bar',
+              \ 'query': {},
+              \ 'fragment': '',
+              \}
+        let want = '\\localhost\C$\foo\bar'
+        Assert Equals(fern#fri#to#uncpath(expr), want)
+      End
+
+      It returns uncpath \\localhost\C$\foo\bar#a&b=c
+        let expr = {
+              \ 'scheme': 'file',
+              \ 'authority': 'localhost',
+              \ 'path': 'C$/foo/bar%23a&b=c',
+              \ 'query': {},
+              \ 'fragment': '',
+              \}
+        let want = '\\localhost\C$\foo\bar#a&b=c'
+        Assert Equals(fern#fri#to#uncpath(expr), want)
+      End
+
+      It returns uncpath \\localhost\C$\foo\bar#foo\bar\hoge
+        let expr = {
+              \ 'scheme': 'file',
+              \ 'authority': 'localhost',
+              \ 'path': 'C$/foo/bar%23foo/bar/hoge',
+              \ 'query': {},
+              \ 'fragment': '',
+              \}
+        let want = '\\localhost\C$\foo\bar#foo\bar\hoge'
+        Assert Equals(fern#fri#to#uncpath(expr), want)
+      End
+    End
+
+    Context Unix
+      Before
+        let g:fern#internal#filepath#is_windows = 0
+      End
+
+      It throws an error always
+        let expr = {
+              \ 'scheme': 'file',
+              \ 'authority': 'qux',
+              \ 'path': 'foo/bar',
+              \ 'query': {},
+              \ 'fragment': '',
+              \}
+        Throws /The system does not support UNC path/ fern#fri#to#uncpath(expr)
+      End
+    End
+  End
+End

--- a/test/fern/internal/complete.vimspec
+++ b/test/fern/internal/complete.vimspec
@@ -301,6 +301,68 @@ Describe fern#internal#complete
       let got = fern#internal#complete#url(arglead, cmdline, cursorpos)
       Assert Equals(got, want)
     End
+
+    Context Windows UNC path
+      Before
+        if !has('win32')
+          Skip because only for Windows
+        endif
+        let unc_test_dir = '\\localhost\' . substitute(test_dir, '^\w\zs:', '$', '')
+        if getftype(unc_test_dir) !=# 'dir'
+          Skip because UNC path is unavailable
+        endif
+        if empty(getcompletion(unc_test_dir, 'dir'))
+          Skip because getcompletion() can not detect UNC path
+        endif
+      End
+
+      It returns directories with UNC path
+        execute 'cd' fnameescape(other_dir)
+        let path = unc_test_dir . '\'
+        let arglead = path
+        let cmdline = 'Fern ' . path
+        let cursorpos = strlen(cmdline)
+        let want = map(['bar', 'baz', 'foo'], { -> path . v:val . '\' })
+        let got = fern#internal#complete#url(arglead, cmdline, cursorpos)
+        Assert Equals(got, want)
+      End
+
+      It returns shares in the host with UNC path
+        let unc_share = matchstr(unc_test_dir, '^\\\\localhost\\\w$\\')
+        let path = '\\localhost\'
+        let arglead = path
+        let cmdline = 'Fern ' . path
+        let cursorpos = strlen(cmdline)
+        let contains = unc_share
+        let got = fern#internal#complete#url(arglead, cmdline, cursorpos)
+        Assert IsList(got)
+        Assert True(index(got, contains) >= 0, printf('but %s do not contains %s', got, string(contains)))
+      End
+
+      It returns directories in the file scheme URL with UNC path
+        execute 'cd' fnameescape(other_dir)
+        let url = fern#fri#format(fern#fri#from#uncpath(unc_test_dir)) . '/'
+        let arglead = url
+        let cmdline = 'Fern ' . url
+        let cursorpos = strlen(cmdline)
+        let want = map(['bar', 'baz', 'foo'], { -> url . v:val })
+        let got = fern#internal#complete#url(arglead, cmdline, cursorpos)
+        Assert Equals(got, want)
+      End
+
+      It returns shares in the host with the file scheme URL with UNC path
+        let unc_share = matchstr(unc_test_dir, '^\\\\localhost\\\w$\\')
+        let unc_share_url = fern#fri#format(fern#fri#from#uncpath(unc_share))
+        let url = fern#fri#format(fern#fri#from#uncpath('\\localhost\'))
+        let arglead = url
+        let cmdline = 'Fern ' . url
+        let cursorpos = strlen(cmdline)
+        let contains = unc_share_url
+        let got = fern#internal#complete#url(arglead, cmdline, cursorpos)
+        Assert IsList(got)
+        Assert True(index(got, contains) >= 0, printf('but %s do not contains %s', got, string(contains)))
+      End
+    End
   End
 
   Describe #reveal()
@@ -449,6 +511,68 @@ Describe fern#internal#complete
       let want = []
       let got = fern#internal#complete#reveal(arglead, cmdline, cursorpos)
       Assert Equals(got, want)
+    End
+
+    Context Windows UNC path
+      Before
+        if !has('win32')
+          Skip because only for Windows
+        endif
+        let unc_test_dir = '\\localhost\' . substitute(test_dir, '^\w\zs:', '$', '')
+        if getftype(unc_test_dir) !=# 'dir'
+          Skip because UNC path is unavailable
+        endif
+        if empty(getcompletion(unc_test_dir, 'dir'))
+          Skip because getcompletion() can not detect UNC path
+        endif
+      End
+
+      It returns files and directories if reveal path is empty
+        execute 'cd' fnameescape(other_dir)
+        let base = unc_test_dir
+        let arglead = '-reveal='
+        let cmdline = printf('Fern %s %s', fnameescape(base), arglead)
+        let cursorpos = strlen(cmdline)
+        let want = map(['bar', 'baz', 'foo', 'qux'], { -> arglead . v:val })
+        let got = fern#internal#complete#reveal(arglead, cmdline, cursorpos)
+        Assert Equals(got, want)
+      End
+
+      It returns files and directories if reveal path is directory
+        execute 'cd' fnameescape(other_dir)
+        let base = fnamemodify(unc_test_dir, ':h')
+        let path = fnamemodify(unc_test_dir, ':t') . pathsep
+        let arglead = '-reveal=' . fnameescape(path)
+        let cmdline = printf('Fern %s %s', fnameescape(base), arglead)
+        let cursorpos = strlen(cmdline)
+        let want = map(['bar', 'baz', 'foo', 'qux'], { -> arglead . v:val })
+        let got = fern#internal#complete#reveal(arglead, cmdline, cursorpos)
+        Assert Equals(got, want)
+      End
+
+      It returns directories in the file scheme URL if reveal path is empty
+        execute 'cd' fnameescape(other_dir)
+        let base_url = fern#fri#format(fern#fri#from#uncpath(unc_test_dir)) . '/'
+        let arglead = '-reveal='
+        let cmdline = printf('Fern %s %s', base_url, arglead)
+        let cursorpos = strlen(cmdline)
+        let want = map(['bar', 'baz', 'foo', 'qux'], { -> arglead . v:val })
+        let got = fern#internal#complete#reveal(arglead, cmdline, cursorpos)
+        Assert Equals(got, want)
+      End
+
+      It returns directories in the file scheme URL if reveal path is directory
+        execute 'cd' fnameescape(other_dir)
+        let base = fnamemodify(unc_test_dir, ':h')
+        let base_url = fern#fri#format(fern#fri#from#uncpath(base)) . '/'
+        let path = fnamemodify(unc_test_dir, ':t') . '/'
+        let arglead = '-reveal=' . path
+        let cmdline = printf('Fern %s %s', base_url, arglead)
+        let cursorpos = strlen(cmdline)
+        let want = map(['bar', 'baz', 'foo', 'qux'], { -> arglead . v:val })
+        let got = fern#internal#complete#reveal(arglead, cmdline, cursorpos)
+        Assert Equals(got, want)
+      End
     End
   End
 End

--- a/test/fern/internal/filepath.vimspec
+++ b/test/fern/internal/filepath.vimspec
@@ -154,6 +154,39 @@ Describe fern#internal#filepath
       End
     End
 
+    Describe #is_unc_compat()
+      It returns 0
+        Assert False(fern#internal#filepath#is_unc_compat())
+      End
+    End
+
+    Describe #is_uncpath()
+      It returns 0 for '/'
+        let path = '/'
+        Assert False(fern#internal#filepath#is_uncpath(path))
+      End
+
+      It returns 0 for ''
+        let path = ''
+        Assert False(fern#internal#filepath#is_uncpath(path))
+      End
+
+      It returns 0 for '/usr/local'
+        let path = '/usr/local'
+        Assert False(fern#internal#filepath#is_uncpath(path))
+      End
+
+      It returns 0 for '\\localhost'
+        let path = '\\localhost'
+        Assert False(fern#internal#filepath#is_uncpath(path))
+      End
+
+      It returns 0 for '\\localhost\C$'
+        let path = '\\localhost\C$'
+        Assert False(fern#internal#filepath#is_uncpath(path))
+      End
+    End
+
     Describe #is_absolute()
       It returns 1 for '/usr/local'
         Assert True(fern#internal#filepath#is_absolute('/usr/local'))
@@ -322,6 +355,16 @@ Describe fern#internal#filepath
         let path = 'C:\Windows\System32'
         Assert False(fern#internal#filepath#is_root(path))
       End
+
+      It returns 0 for '\\localhost'
+        let path = '\\localhost'
+        Assert False(fern#internal#filepath#is_root(path))
+      End
+
+      It returns 0 for '\\localhost\C$'
+        let path = '\\localhost\C$'
+        Assert False(fern#internal#filepath#is_root(path))
+      End
     End
 
     Describe #is_drive_root()
@@ -338,6 +381,49 @@ Describe fern#internal#filepath
       It returns 0 for 'C:\Windows\System32'
         let path = 'C:\Windows\System32'
         Assert False(fern#internal#filepath#is_drive_root(path))
+      End
+
+      It returns 0 for '\\localhost'
+        let path = '\\localhost'
+        Assert False(fern#internal#filepath#is_drive_root(path))
+      End
+
+      It returns 0 for '\\localhost\C$'
+        let path = '\\localhost\C$'
+        Assert False(fern#internal#filepath#is_drive_root(path))
+      End
+    End
+
+    Describe #is_unc_compat()
+      It returns 1
+        Assert True(fern#internal#filepath#is_unc_compat())
+      End
+    End
+
+    Describe #is_uncpath()
+      It returns 0 for 'C:\'
+        let path = 'C:\'
+        Assert False(fern#internal#filepath#is_uncpath(path))
+      End
+
+      It returns 0 for ''
+        let path = ''
+        Assert False(fern#internal#filepath#is_uncpath(path))
+      End
+
+      It returns 0 for 'C:\Windows\System32'
+        let path = 'C:\Windows\System32'
+        Assert False(fern#internal#filepath#is_uncpath(path))
+      End
+
+      It returns 1 for '\\localhost'
+        let path = '\\localhost'
+        Assert True(fern#internal#filepath#is_uncpath(path))
+      End
+
+      It returns 1 for '\\localhost\C$'
+        let path = '\\localhost\C$'
+        Assert True(fern#internal#filepath#is_uncpath(path))
       End
     End
 
@@ -360,6 +446,16 @@ Describe fern#internal#filepath
 
       It returns 0 for 'Windows'
         Assert False(fern#internal#filepath#is_absolute('Windows'))
+      End
+
+      It returns 1 for '\\localhost'
+        let path = '\\localhost'
+        Assert True(fern#internal#filepath#is_absolute(path))
+      End
+
+      It returns 1 for '\\localhost\C$'
+        let path = '\\localhost\C$'
+        Assert True(fern#internal#filepath#is_absolute(path))
       End
     End
 


### PR DESCRIPTION
Unfortunately neovim does not support UNC path.

### in neovim 0.4.4
* `getftype('\\localhost\C$\')` => 'dir' 👌
* `glob('\\localhost\C$\*')` => [] 😢
* `getcompletion('\\localhost\C$\', 'file')` => [] 😢