### PR TITLE
Add highlight group used for spinner

### DIFF
--- a/autoload/fern/internal/spinner.vim
+++ b/autoload/fern/internal/spinner.vim
@@ -49,7 +49,7 @@ function! s:define_signs() abort
   let frames = g:fern#internal#spinner#frames
   for index in range(len(frames))
     call execute(printf(
-          \ 'sign define FernSignSpinner%d text=%s',
+          \ 'sign define FernSignSpinner%d text=%s texthl=FernSpinner',
           \ index,
           \ frames[index],
           \))

--- a/doc/fern.txt
+++ b/doc/fern.txt
@@ -728,6 +728,9 @@ FernSyntax
 -----------------------------------------------------------------------------
 HIGHLIGHT						*fern-highlight*
 
+FernSpinner					*hl-FernSpinner*
+	A |highlight| group used as a text highlight of spinner |sign|.
+
 FernMarkedLine					*hl-FernMarkedLine*
 	A |highlight| group used as a line highlight of mark |sign|.
 


### PR DESCRIPTION
I think it would be useful if users could customize the color of spinner, so I added `FernSpinner` highlight group for it.

If you prefer a different name, please let me know and I'll change it.