### PR TITLE
Disable auto-resize on flaoting window of Neovim

### DIFF
--- a/autoload/fern/internal/drawer/auto_resize.vim
+++ b/autoload/fern/internal/drawer/auto_resize.vim
@@ -5,7 +5,22 @@ function! fern#internal#drawer#auto_resize#init() abort
 
   augroup fern_internal_drawer_init
     autocmd! * <buffer>
-    autocmd BufEnter <buffer> call fern#internal#drawer#resize()
-    autocmd BufLeave <buffer> call fern#internal#drawer#resize()
+    autocmd BufEnter <buffer> call s:resize()
+    autocmd BufLeave <buffer> call s:resize()
   augroup END
 endfunction
+
+if has('nvim')
+  function! s:is_relative() abort
+    return nvim_win_get_config(win_getid()).relative !=# ''
+  endfunction
+
+  function! s:resize() abort
+    if s:is_relative()
+      return
+    endif
+    call fern#internal#drawer#resize()
+  endfunction
+else
+  let s:resize = funcref('fern#internal#drawer#resize')
+endif

--- a/doc/fern.txt
+++ b/doc/fern.txt
@@ -432,6 +432,11 @@ VARIABLE						*fern-variable*
 *g:fern#disable_drawer_auto_resize*
 	Set 1 to disable automatically resize drawer on |BufEnter| and
 	|BufLeave| autocmd.
+
+	Note that this feature is automatically disabled on floating windows
+	of Neovim to avoid unwilling resize reported as #294
+	https://github.com/lambdalisue/fern.vim/issues/294
+
 	Default: 0 
 
 *g:fern#disable_drawer_auto_quit*


### PR DESCRIPTION
Close #294 