### PR TITLE
Change behavior of "auto resize" and improve "zoom" related actions

### DIFF
--- a/autoload/fern/internal/drawer/auto_resize.vim
+++ b/autoload/fern/internal/drawer/auto_resize.vim
@@ -5,22 +5,35 @@ function! fern#internal#drawer#auto_resize#init() abort
 
   augroup fern_internal_drawer_init
     autocmd! * <buffer>
-    autocmd BufEnter <buffer> call s:resize()
-    autocmd BufLeave <buffer> call s:resize()
+    autocmd BufEnter <buffer> call s:load_width()
+    autocmd BufLeave <buffer> call s:save_width()
   augroup END
 endfunction
 
 if has('nvim')
-  function! s:is_relative() abort
+  function! s:should_ignore() abort
     return nvim_win_get_config(win_getid()).relative !=# ''
   endfunction
-
-  function! s:resize() abort
-    if s:is_relative()
-      return
-    endif
-    call fern#internal#drawer#resize()
-  endfunction
 else
-  let s:resize = funcref('fern#internal#drawer#resize')
+  function! s:should_ignore() abort
+    return 0
+  endfunction
 endif
+
+function! s:save_width() abort
+  if s:should_ignore()
+    return
+  endif
+  let t:fern_drawer_auto_resize_width = winwidth(0)
+endfunction
+
+function! s:load_width() abort
+  if s:should_ignore()
+    return
+  endif
+  if !exists('t:fern_drawer_auto_resize_width')
+    call fern#internal#drawer#resize()
+  else
+    execute 'vertical resize' t:fern_drawer_auto_resize_width
+  endif
+endfunction

--- a/autoload/fern/mapping/drawer.vim
+++ b/autoload/fern/mapping/drawer.vim
@@ -24,7 +24,8 @@ function! s:map_zoom(helper) abort
   endif
   let alpha = v:count
   if alpha <= 0 || alpha > 10
-    let alpha = s:input_alpha('Width ratio [1-10]: ')
+    let current = float2nr(ceil(str2float(winwidth(0)) / &columns * 10))
+    let alpha = s:input_alpha(printf('Width ratio [%d -> 1-10]: ', current))
   endif
   let alpha = str2float(alpha)
   let width = &columns * (alpha / 10)

--- a/autoload/fern/mapping/drawer.vim
+++ b/autoload/fern/mapping/drawer.vim
@@ -26,6 +26,9 @@ function! s:map_zoom(helper) abort
   if alpha <= 0 || alpha > 10
     let current = float2nr(ceil(str2float(winwidth(0)) / &columns * 10))
     let alpha = s:input_alpha(printf('Width ratio [%d -> 1-10]: ', current))
+    if alpha is# v:null
+      return
+    endif
   endif
   let alpha = str2float(alpha)
   let width = &columns * (alpha / 10)
@@ -43,7 +46,10 @@ endfunction
 function! s:input_alpha(prompt) abort
   while v:true
     let result = input(a:prompt)
-    if result =~# '^\%(10\|[1-9]\)$'
+    if result ==# ''
+      redraw | echo ''
+      return v:null
+    elseif result =~# '^\%(10\|[1-9]\)$'
       redraw | echo ''
       return result
     endif

--- a/autoload/fern/mapping/drawer.vim
+++ b/autoload/fern/mapping/drawer.vim
@@ -1,11 +1,12 @@
 function! fern#mapping#drawer#init(disable_default_mappings) abort
-  nnoremap <buffer><silent> <Plug>(fern-action-zoom:half) :<C-u>call <SID>call('zoom', 0.4)<CR>
-  nnoremap <buffer><silent> <Plug>(fern-action-zoom:full) :<C-u>call <SID>call('zoom', 0.9)<CR>
-
-  nmap <buffer> <Plug>(fern-action-zoom) <Plug>(fern-action-zoom:half)
+  nnoremap <buffer><silent> <Plug>(fern-action-zoom) :<C-u>call <SID>call('zoom')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-zoom:reset) :<C-u>call <SID>call('zoom_reset')<CR>
+  nmap <buffer><silent> <Plug>(fern-action-zoom:half) 4<Plug>(fern-action-zoom)
+  nmap <buffer><silent> <Plug>(fern-action-zoom:full) 9<Plug>(fern-action-zoom)
 
   if !a:disable_default_mappings
     nmap <buffer><nowait> z <Plug>(fern-action-zoom)
+    nmap <buffer><nowait> Z <Plug>(fern-action-zoom:reset)
   endif
 endfunction
 
@@ -16,9 +17,35 @@ function! s:call(name, ...) abort
         \)
 endfunction
 
-function! s:map_zoom(helper, alpha) abort
-  if fern#internal#drawer#is_drawer()
-    let width = &columns * a:alpha
-    execute printf('%d wincmd |', float2nr(width))
+function! s:map_zoom(helper) abort
+  if !fern#internal#drawer#is_drawer()
+    call fern#warn('zoom is available only on drawer')
+    return
   endif
+  let alpha = v:count
+  if alpha <= 0 || alpha > 10
+    let alpha = s:input_alpha('Width ratio [1-10]: ')
+  endif
+  let alpha = str2float(alpha)
+  let width = &columns * (alpha / 10)
+  execute 'vertical resize' float2nr(width)
+endfunction
+
+function! s:map_zoom_reset(helper) abort
+  if !fern#internal#drawer#is_drawer()
+    call fern#warn('zoom:resize is available only on drawer')
+    return
+  endif
+  call fern#internal#drawer#resize()
+endfunction
+
+function! s:input_alpha(prompt) abort
+  while v:true
+    let result = input(a:prompt)
+    if result =~# '^\%(10\|[1-9]\)$'
+      redraw | echo ''
+      return result
+    endif
+    redraw | echo 'Please input a digit from 1 to 10'
+  endwhile
 endfunction

--- a/doc/fern.txt
+++ b/doc/fern.txt
@@ -422,8 +422,7 @@ VARIABLE						*fern-variable*
 	Default: 0
 
 *g:fern#disable_drawer_auto_resize*
-	Set 1 to disable automatically resize drawer on |BufEnter| and
-	|BufLeave| autocmd.
+	Set 1 to disable automatically resize drawer on |BufEnter| autocmd.
 
 	Note that this feature is automatically disabled on floating windows
 	of Neovim to avoid unwilling resize reported as #294

--- a/doc/fern.txt
+++ b/doc/fern.txt
@@ -781,15 +781,21 @@ See |fern-action| for more detail.
 -----------------------------------------------------------------------------
 GLOBAL							*fern-mapping-global*
 
-*<Plug>(fern-action-zoom:half)*
-	Zoom width of the drawer style fern to half of the global width.
-	The original window width will be restored once user leave the window.
+*<Plug>(fern-action-zoom)*
+	Zoom width of the drawer style fern to the ratio of the global width.
+	It prompt users to ask a desired ratio of the width if no |v:count| is
+	given. Users can use 1 to 10 for the ratio.
 	It only works on a drawer style fern window.
 
-*<Plug>(fern-action-zoom:full)*
-	Zoom width of the drawer style fern to full of the global width.
-	The original window width will be restored once user leave the window.
+*<Plug>(fern-action-zoom:reset)*
+	Reset the width of the drawer style fern to its original width.
 	It only works on a drawer style fern window.
+
+*<Plug>(fern-action-zoom:half)*
+	This is an alias of "4<Plug>(fern-action-zoom)"
+
+*<Plug>(fern-action-zoom:full)*
+	This is an alias of "9<Plug>(fern-action-zoom)"
 
 *<Plug>(fern-action-hidden:set)*
 	Show hidden nodes. For example hidden nodes in file:// scheme is a


### PR DESCRIPTION
To help usage explained in #309 

- :boom: Behavior changed. Fern restore the previous drawer width on the `BufEnter` autocmd to fix #309 
  - It's more natural to restore the previous width rather than the original one
  - Users can use `<Plug>(fern-action-zoom:reset)` action to mimic previous behavior if they desire
- :boom: Behavior changed. The `zoom` action opens a prompt to ask a desired width ratio or respects `v:count`
  - For example, users can use `8z` to make the drawer width 80% of the Vim window
  - Users can map `<Plug>(fern-action-zoom:half)` or `<Plug>(fern-action-zoom:full)` to `z` to get back the previous mapping
- :sparkles: Feature added: The `zoom:reset` action is added to easily get back to the original width of the drawer

---

In the video below, I use the following mappings (and those mappings are defined as default mappings)

- `z` is mapped to `<Plug>(fern-action-zoom)`
- `Z` is mapped to `<Plug>(fern-action-zoom:reset)`

https://user-images.githubusercontent.com/546312/116769767-aa4efc80-aa79-11eb-9a9b-925ec466ed5c.mp4

