### PR TITLE
Add `diff` and `ex` actions

### DIFF
--- a/autoload/fern/mapping.vim
+++ b/autoload/fern/mapping.vim
@@ -34,6 +34,7 @@ endfunction
 
 call s:Config.config(expand('<sfile>:p'), {
       \ 'mappings': [
+      \   'diff',
       \   'drawer',
       \   'filter',
       \   'mark',

--- a/autoload/fern/mapping/diff.vim
+++ b/autoload/fern/mapping/diff.vim
@@ -1,0 +1,144 @@
+let s:Promise = vital#fern#import('Async.Promise')
+let s:timer_diffupdate = 0
+
+function! fern#mapping#diff#init(disable_default_mappings) abort
+  nnoremap <buffer><silent> <Plug>(fern-action-diff:select)   :<C-u>call <SID>call('diff', 'select', v:false)<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-diff:split)    :<C-u>call <SID>call('diff', 'split', v:false)<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-diff:vsplit)   :<C-u>call <SID>call('diff', 'vsplit', v:false)<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-diff:tabedit)  :<C-u>call <SID>call('diff', 'tabedit', v:false)<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-diff:above)    :<C-u>call <SID>call('diff', 'leftabove split', v:false)<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-diff:left)     :<C-u>call <SID>call('diff', 'leftabove vsplit', v:false)<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-diff:below)    :<C-u>call <SID>call('diff', 'rightbelow split', v:false)<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-diff:right)    :<C-u>call <SID>call('diff', 'rightbelow vsplit', v:false)<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-diff:top)      :<C-u>call <SID>call('diff', 'topleft split', v:false)<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-diff:leftest)  :<C-u>call <SID>call('diff', 'topleft vsplit', v:false)<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-diff:bottom)   :<C-u>call <SID>call('diff', 'botright split', v:false)<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-diff:rightest) :<C-u>call <SID>call('diff', 'botright vsplit', v:false)<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-diff:edit-or-error)   :<C-u>call <SID>call('diff', 'edit', v:false)<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-diff:edit-or-split)   :<C-u>call <SID>call('diff', 'edit/split', v:false)<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-diff:edit-or-vsplit)  :<C-u>call <SID>call('diff', 'edit/vsplit', v:false)<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-diff:edit-or-tabedit) :<C-u>call <SID>call('diff', 'edit/tabedit', v:false)<CR>
+
+  nnoremap <buffer><silent> <Plug>(fern-action-diff:select:vert)   :<C-u>call <SID>call('diff', 'select', v:true)<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-diff:split:vert)    :<C-u>call <SID>call('diff', 'split', v:true)<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-diff:vsplit:vert)   :<C-u>call <SID>call('diff', 'vsplit', v:true)<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-diff:tabedit:vert)  :<C-u>call <SID>call('diff', 'tabedit', v:true)<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-diff:above:vert)    :<C-u>call <SID>call('diff', 'leftabove split', v:true)<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-diff:left:vert)     :<C-u>call <SID>call('diff', 'leftabove vsplit', v:true)<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-diff:below:vert)    :<C-u>call <SID>call('diff', 'rightbelow split', v:true)<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-diff:right:vert)    :<C-u>call <SID>call('diff', 'rightbelow vsplit', v:true)<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-diff:top:vert)      :<C-u>call <SID>call('diff', 'topleft split', v:true)<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-diff:leftest:vert)  :<C-u>call <SID>call('diff', 'topleft vsplit', v:true)<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-diff:bottom:vert)   :<C-u>call <SID>call('diff', 'botright split', v:true)<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-diff:rightest:vert) :<C-u>call <SID>call('diff', 'botright vsplit', v:true)<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-diff:edit-or-error:vert)   :<C-u>call <SID>call('diff', 'edit', v:true)<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-diff:edit-or-split:vert)   :<C-u>call <SID>call('diff', 'edit/split', v:true)<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-diff:edit-or-vsplit:vert)  :<C-u>call <SID>call('diff', 'edit/vsplit', v:true)<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-diff:edit-or-tabedit:vert) :<C-u>call <SID>call('diff', 'edit/tabedit', v:true)<CR>
+
+  " Smart map
+  nmap <buffer><silent><expr>
+        \ <Plug>(fern-action-diff:side)
+        \ fern#smart#drawer(
+        \   "\<Plug>(fern-action-diff:left)",
+        \   "\<Plug>(fern-action-diff:right)",
+        \ )
+  nmap <buffer><silent><expr>
+        \ <Plug>(fern-action-diff:side:vert)
+        \ fern#smart#drawer(
+        \   "\<Plug>(fern-action-diff:left:vert)",
+        \   "\<Plug>(fern-action-diff:right:vert)",
+        \ )
+
+  " Alias map
+  nmap <buffer><silent> <Plug>(fern-action-diff:edit) <Plug>(fern-action-diff:edit-or-error)
+  nmap <buffer><silent> <Plug>(fern-action-diff:edit:vert) <Plug>(fern-action-diff:edit-or-error:vert)
+  nmap <buffer><silent> <Plug>(fern-action-diff) <Plug>(fern-action-diff:edit)
+  nmap <buffer><silent> <Plug>(fern-action-diff:vert) <Plug>(fern-action-diff:edit:vert)
+endfunction
+
+function! s:call(name, ...) abort
+  return call(
+        \ 'fern#mapping#call',
+        \ [funcref(printf('s:map_%s', a:name))] + a:000,
+        \)
+endfunction
+
+function! s:map_diff(helper, opener, vert) abort
+  let nodes = a:helper.sync.get_selected_nodes()
+  let nodes = filter(copy(nodes), { -> v:val.bufname isnot# v:null })
+  if empty(nodes)
+    return s:Promise.reject('no node found which has bufname')
+  elseif len(nodes) < 2
+    return s:Promise.reject('at least two nodes are required to perform diff')
+  endif
+  try
+    let is_drawer = a:helper.sync.is_drawer()
+    let first = nodes[0]
+    let nodes = nodes[1:]
+    call fern#internal#buffer#open(first.bufname, {
+          \ 'opener': a:opener,
+          \ 'locator': is_drawer,
+          \ 'keepalt': !is_drawer && g:fern#keepalt_on_edit,
+          \ 'keepjumps': !is_drawer && g:fern#keepjumps_on_edit,
+          \})
+    call s:diffthis()
+    let winid = win_getid()
+    for node in nodes
+      noautocmd call win_gotoid(winid)
+      call fern#internal#buffer#open(node.bufname, {
+            \ 'opener': a:vert ? 'vsplit' : 'split',
+            \ 'locator': is_drawer,
+            \ 'keepalt': !is_drawer && g:fern#keepalt_on_edit,
+            \ 'keepjumps': !is_drawer && g:fern#keepjumps_on_edit,
+            \})
+      call s:diffthis()
+    endfor
+    call s:diffupdate()
+    normal! zm
+    " Fix <C-w><C-p> (#47)
+    let winid_fern = win_getid()
+    noautocmd call win_gotoid(winid)
+    noautocmd call win_gotoid(winid_fern)
+    return a:helper.async.update_marks([])
+        \.then({ -> a:helper.async.remark() })
+  catch
+    return s:Promise.reject(v:exception)
+  endtry
+endfunction
+
+function! s:diffthis() abort
+  diffthis
+  augroup fern_mapping_diff_internal
+    autocmd! * <buffer>
+    autocmd BufReadPost <buffer>
+          \ if &diff && &foldmethod !=# 'diff' |
+          \   setlocal foldmethod=diff |
+          \ endif
+  augroup END
+endfunction
+
+function! s:diffupdate() abort
+  " NOTE:
+  " 'diffupdate' does not work just after a buffer has opened
+  " so use timer to delay the command.
+  silent! call timer_stop(s:timer_diffupdate)
+  let s:timer_diffupdate = timer_start(100, function('s:diffupdate_internal', [bufnr('%')]))
+endfunction
+
+function! s:diffupdate_internal(bufnr, ...) abort
+  let winid = bufwinid(a:bufnr)
+  if winid == -1
+    return
+  endif
+  let winid_saved = win_getid()
+  try
+    if winid != winid_saved
+      call win_gotoid(winid)
+    endif
+    diffupdate
+    syncbind
+  finally
+    call win_gotoid(winid_saved)
+  endtry
+endfunction

--- a/autoload/fern/scheme/file/mapping.vim
+++ b/autoload/fern/scheme/file/mapping.vim
@@ -241,6 +241,7 @@ endfunction
 let g:fern#scheme#file#mapping#mappings = get(g:, 'fern#scheme#file#mapping#mappings', [
       \ 'cd',
       \ 'clipboard',
+      \ 'ex',
       \ 'grep',
       \ 'rename',
       \ 'system',

--- a/autoload/fern/scheme/file/mapping/ex.vim
+++ b/autoload/fern/scheme/file/mapping/ex.vim
@@ -1,0 +1,30 @@
+let s:Promise = vital#fern#import('Async.Promise')
+
+function! fern#scheme#file#mapping#ex#init(disable_default_mappings) abort
+  nnoremap <buffer><silent> <Plug>(fern-action-ex) :<C-u>call <SID>call('ex')<CR>
+endfunction
+
+function! s:call(name, ...) abort
+  return call(
+       \ 'fern#mapping#call',
+       \ [funcref(printf('s:map_%s', a:name))] + a:000,
+       \)
+endfunction
+
+function! s:map_ex(helper) abort
+  let nodes = a:helper.sync.get_selected_nodes()
+  let nodes = filter(copy(nodes), { -> v:val._path isnot# v:null })
+  if empty(nodes)
+    return
+  endif
+  call feedkeys("\<Home>", 'in')
+  let expr = join(map(copy(nodes), { _, v -> fnamemodify(v._path, ':~:.') }), ' ')
+  let expr = input(':', ' ' . expr, 'command')
+  if empty(expr)
+    return
+  endif
+  if a:helper.sync.is_drawer()
+    call fern#internal#locator#focus(winnr('#'))
+  endif
+  execute expr
+endfunction

--- a/doc/fern.txt
+++ b/doc/fern.txt
@@ -1102,6 +1102,10 @@ FILE							*fern-mapping-file*
 
 The following mappings/actions are only available on file:// scheme.
 
+*<Plug>(fern-action-ex)*
+	Open a prompt to execute an Ex command with a path of cursor node or 
+	paths of marked nodes.
+
 *<Plug>(fern-action-new-path)*
 	Open a prompt to ask a path and create a file/directory of the input
 	path from the path of a cursor node.

--- a/doc/fern.txt
+++ b/doc/fern.txt
@@ -980,6 +980,95 @@ GLOBAL							*fern-mapping-global*
 	      \ <Plug>(fern-action-open)
 	      \ <Plug>(fern-action-open:select)
 <
+*<Plug>(fern-action-diff:select)*
+*<Plug>(fern-action-diff:select:vert)*
+	Open a first marked node through "window selector"
+	(|fern-glossary-window-selector|.) then open remains with |split| or
+	|vsplit| (:vert) to compare content through |diff| feature.
+
+*<Plug>(fern-action-diff:split)*
+*<Plug>(fern-action-diff:split:vert)*
+*<Plug>(fern-action-diff:vsplit)*
+*<Plug>(fern-action-diff:vsplit:vert)*
+*<Plug>(fern-action-diff:tabedit)*
+*<Plug>(fern-action-diff:tabedit:vert)*
+	Open a first marked node with a corresponding command then open remains
+	with |split| or |vsplit| (:vert) to compare contents through |diff|
+	feature.
+	The command will be applied on an "anchor" window when invoked from a
+	drawer style fern (|fern-glossary-anchor|.)
+
+*<Plug>(fern-action-diff:edit-or-error)*
+*<Plug>(fern-action-diff:edit-or-error:vert)*
+	Open a first marked node with |edit| command or fallback to print an
+	error then open remains with |split| or |vsplit| (:vert) to compare
+	contents through |diff| feature.
+	Note that when 'hidden' has set or 'bufhidden' is "hide", the |edit|
+	command will never fails.
+
+*<Plug>(fern-action-diff:edit-or-split)*
+*<Plug>(fern-action-diff:edit-or-split:vert)*
+*<Plug>(fern-action-diff:edit-or-vsplit)*
+*<Plug>(fern-action-diff:edit-or-vsplit:vert)*
+*<Plug>(fern-action-diff:edit-or-tabedit)*
+*<Plug>(fern-action-diff:edit-or-tabedit:vert)*
+	Open a first marked node with |edit| command or fallback to a 
+	corresponding command then .
+	Note that when 'hidden' has set or 'bufhidden' is "hide", the |edit|
+	command will never fails.
+
+*<Plug>(fern-action-diff:above)*
+*<Plug>(fern-action-diff:above:vert)*
+*<Plug>(fern-action-diff:left)*
+*<Plug>(fern-action-diff:left:vert)*
+*<Plug>(fern-action-diff:below)*
+*<Plug>(fern-action-diff:below:vert)*
+*<Plug>(fern-action-diff:right)*
+*<Plug>(fern-action-diff:right:vert)*
+	Open a first marked node on a corresponding direction from an "anchor"
+	window then open remains with |split| or |vsplit| (:vert) to compare
+	contents through |diff| feature.
+	The command will be applied on the anchor window when invoked from a
+	drawer style fern (|fern-glossary-anchor|.)
+
+*<Plug>(fern-action-diff:top)*
+*<Plug>(fern-action-diff:top:vert)*
+*<Plug>(fern-action-diff:leftest)*
+*<Plug>(fern-action-diff:leftest:vert)*
+*<Plug>(fern-action-diff:bottom)*
+*<Plug>(fern-action-diff:bottom:vert)*
+*<Plug>(fern-action-diff:rightest)*
+*<Plug>(fern-action-diff:rightest:vert)*
+	Open a first marked node on a edge of a corresponding direction from
+	an "anchor" window then open remains with |split| or |vsplit| (:vert)
+	to compare contents through |diff| feature.
+	The command will be applied on the anchor window when invoked from a
+	drawer style fern (|fern-glossary-anchor|.)
+
+*<Plug>(fern-action-diff:side)*
+*<Plug>(fern-action-diff:side:vert)*
+	Open a first marked node on the right side of the current window then
+	open remains with |split| or |vsplit| (:vert) to compare contents
+	through |diff| feature.
+	The behavior is slightly different between a drawer style fern
+	window and a split style fern window due to the presence of "anchor".
+
+*<Plug>(fern-action-diff:edit)*
+	An alias to "diff:edit-or-error" action. Users can overwrite this
+	mapping to change the default behavior of "diff:edit" action like:
+>
+	nmap <buffer> 
+	      \ <Plug>(fern-action-diff:edit)
+	      \ <Plug>(fern-action-diff:edit-or-tabedit)
+<
+*<Plug>(fern-action-diff)*
+	An alias to "diff:edit" action. Users can overwrite this mapping to
+	change the default behavior of "diff" action like:
+>
+	nmap <buffer> 
+	      \ <Plug>(fern-action-diff)
+	      \ <Plug>(fern-action-diff:select)
+<
 *<Plug>(fern-action-cancel)*
 	Cancel tree rendering.
 

--- a/doc/fern.txt
+++ b/doc/fern.txt
@@ -919,7 +919,7 @@ GLOBAL							*fern-mapping-global*
 	The command will be applied on an "anchor" window when invoked from a
 	drawer style fern (|fern-glossary-anchor|.)
 
-*<Plug>(fern-action-edit-or-error)*
+*<Plug>(fern-action-open:edit-or-error)*
 	Open a cursor node or marked nodes with |edit| command or fallback
 	to print an error. 
 	Note that when 'hidden' has set or 'bufhidden' is "hide", the |edit|


### PR DESCRIPTION
### `diff`

Users can use `diff` action to compare buffer contents of multiple nodes.

https://user-images.githubusercontent.com/546312/124349629-0b867e00-dc2b-11eb-91ac-67a1d7741433.mp4

### `ex`

Users can use `ex` action to execute arbitrary Ex command on selected nodes.


https://user-images.githubusercontent.com/546312/124349659-52747380-dc2b-11eb-8df3-601aa8a30820.mp4

