### PR TITLE
Add `=` action variants to several actions for providing default value

### DIFF
--- a/autoload/fern/mapping.vim
+++ b/autoload/fern/mapping.vim
@@ -13,6 +13,15 @@ function! fern#mapping#call(fn, ...) abort
   endtry
 endfunction
 
+function! fern#mapping#call_without_guard(fn, ...) abort
+  try
+    call s:Promise.resolve(call('fern#helper#call', [a:fn] + a:000))
+          \.catch({ e -> fern#logger#error(e) })
+  catch
+    call fern#logger#error(v:exception)
+  endtry
+endfunction
+
 function! fern#mapping#init(scheme) abort
   let disable_default_mappings = g:fern#disable_default_mappings
   for name in g:fern#mapping#mappings

--- a/autoload/fern/mapping/filter.vim
+++ b/autoload/fern/mapping/filter.vim
@@ -2,8 +2,10 @@ function! fern#mapping#filter#init(disable_default_mappings) abort
   nnoremap <buffer><silent> <Plug>(fern-action-hidden:set)    :<C-u>call <SID>call('hidden_set')<CR>
   nnoremap <buffer><silent> <Plug>(fern-action-hidden:unset)  :<C-u>call <SID>call('hidden_unset')<CR>
   nnoremap <buffer><silent> <Plug>(fern-action-hidden:toggle) :<C-u>call <SID>call('hidden_toggle')<CR>
-  nnoremap <buffer><silent> <Plug>(fern-action-include)     :<C-u>call <SID>call('include')<CR>
-  nnoremap <buffer><silent> <Plug>(fern-action-exclude)     :<C-u>call <SID>call('exclude')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-include)       :<C-u>call <SID>call('include')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-exclude)       :<C-u>call <SID>call('exclude')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-include=)      :<C-u>call <SID>call_without_guard('include')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-exclude=)      :<C-u>call <SID>call_without_guard('exclude')<CR>
 
   " Alias
   nmap <buffer> <Plug>(fern-action-hidden) <Plug>(fern-action-hidden:toggle)
@@ -26,6 +28,13 @@ endfunction
 function! s:call(name, ...) abort
   return call(
         \ 'fern#mapping#call',
+        \ [funcref(printf('s:map_%s', a:name))] + a:000,
+        \)
+endfunction
+
+function! s:call_without_guard(name, ...) abort
+  return call(
+        \ 'fern#mapping#call_without_guard',
         \ [funcref(printf('s:map_%s', a:name))] + a:000,
         \)
 endfunction

--- a/autoload/fern/mapping/node.vim
+++ b/autoload/fern/mapping/node.vim
@@ -9,6 +9,7 @@ function! fern#mapping#node#init(disable_default_mappings) abort
   nnoremap <buffer><silent> <Plug>(fern-action-expand:in)     :<C-u>call <SID>call('expand_in')<CR>
   nnoremap <buffer><silent> <Plug>(fern-action-collapse)      :<C-u>call <SID>call('collapse')<CR>
   nnoremap <buffer><silent> <Plug>(fern-action-reveal)        :<C-u>call <SID>call('reveal')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-reveal=)       :<C-u>call <SID>call_without_guard('reveal')<CR>
   nnoremap <buffer><silent> <Plug>(fern-action-focus:parent)  :<C-u>call <SID>call('focus_parent')<CR>
 
   nnoremap <buffer><silent> <Plug>(fern-action-enter)         :<C-u>call <SID>call('enter')<CR>
@@ -32,6 +33,13 @@ endfunction
 function! s:call(name, ...) abort
   return call(
         \ 'fern#mapping#call',
+        \ [funcref(printf('s:map_%s', a:name))] + a:000,
+        \)
+endfunction
+
+function! s:call_without_guard(name, ...) abort
+  return call(
+        \ 'fern#mapping#call_without_guard',
         \ [funcref(printf('s:map_%s', a:name))] + a:000,
         \)
 endfunction

--- a/autoload/fern/scheme/file/mapping.vim
+++ b/autoload/fern/scheme/file/mapping.vim
@@ -2,13 +2,16 @@ let s:Promise = vital#fern#import('Async.Promise')
 let s:Prompt = vital#fern#import('Prompt')
 
 function! fern#scheme#file#mapping#init(disable_default_mappings) abort
-  nnoremap <buffer><silent> <Plug>(fern-action-new-path) :<C-u>call <SID>call('new_path')<CR>
-  nnoremap <buffer><silent> <Plug>(fern-action-new-file) :<C-u>call <SID>call('new_file')<CR>
-  nnoremap <buffer><silent> <Plug>(fern-action-new-dir)  :<C-u>call <SID>call('new_dir')<CR>
-  nnoremap <buffer><silent> <Plug>(fern-action-copy)     :<C-u>call <SID>call('copy')<CR>
-  nnoremap <buffer><silent> <Plug>(fern-action-move)     :<C-u>call <SID>call('move')<CR>
-  nnoremap <buffer><silent> <Plug>(fern-action-trash)    :<C-u>call <SID>call('trash')<CR>
-  nnoremap <buffer><silent> <Plug>(fern-action-remove)   :<C-u>call <SID>call('remove')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-new-path)  :<C-u>call <SID>call('new_path')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-new-file)  :<C-u>call <SID>call('new_file')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-new-dir)   :<C-u>call <SID>call('new_dir')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-new-path=) :<C-u>call <SID>call_without_guard('new_path')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-new-file=) :<C-u>call <SID>call_without_guard('new_file')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-new-dir=)  :<C-u>call <SID>call_without_guard('new_dir')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-copy)      :<C-u>call <SID>call('copy')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-move)      :<C-u>call <SID>call('move')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-trash)     :<C-u>call <SID>call('trash')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-remove)    :<C-u>call <SID>call('remove')<CR>
 
   if !a:disable_default_mappings
     nmap <buffer><nowait> N <Plug>(fern-action-new-file)
@@ -22,6 +25,13 @@ endfunction
 function! s:call(name, ...) abort
   return call(
         \ 'fern#mapping#call',
+        \ [funcref(printf('s:map_%s', a:name))] + a:000,
+        \)
+endfunction
+
+function! s:call_without_guard(name, ...) abort
+  return call(
+        \ 'fern#mapping#call_without_guard',
         \ [funcref(printf('s:map_%s', a:name))] + a:000,
         \)
 endfunction

--- a/autoload/fern/scheme/file/mapping/ex.vim
+++ b/autoload/fern/scheme/file/mapping/ex.vim
@@ -1,12 +1,20 @@
 let s:Promise = vital#fern#import('Async.Promise')
 
 function! fern#scheme#file#mapping#ex#init(disable_default_mappings) abort
-  nnoremap <buffer><silent> <Plug>(fern-action-ex) :<C-u>call <SID>call('ex')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-ex)  :<C-u>call <SID>call('ex')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-ex=) :<C-u>call <SID>call_without_guard('ex')<CR>
 endfunction
 
 function! s:call(name, ...) abort
   return call(
        \ 'fern#mapping#call',
+       \ [funcref(printf('s:map_%s', a:name))] + a:000,
+       \)
+endfunction
+
+function! s:call_without_guard(name, ...) abort
+  return call(
+       \ 'fern#mapping#call_without_guard',
        \ [funcref(printf('s:map_%s', a:name))] + a:000,
        \)
 endfunction

--- a/autoload/fern/scheme/file/mapping/grep.vim
+++ b/autoload/fern/scheme/file/mapping/grep.vim
@@ -3,12 +3,20 @@ let s:Promise = vital#fern#import('Async.Promise')
 let s:Process = vital#fern#import('Async.Promise.Process')
 
 function! fern#scheme#file#mapping#grep#init(disable_default_mappings) abort
-  nnoremap <buffer><silent> <Plug>(fern-action-grep) :<C-u>call <SID>call('grep')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-grep)  :<C-u>call <SID>call('grep')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-grep=) :<C-u>call <SID>call_without_guard('grep')<CR>
 endfunction
 
 function! s:call(name, ...) abort
   return call(
         \ 'fern#mapping#call',
+        \ [funcref(printf('s:map_%s', a:name))] + a:000,
+        \)
+endfunction
+
+function! s:call_without_guard(name, ...) abort
+  return call(
+        \ 'fern#mapping#call_without_guard',
         \ [funcref(printf('s:map_%s', a:name))] + a:000,
         \)
 endfunction

--- a/doc/fern.txt
+++ b/doc/fern.txt
@@ -823,13 +823,29 @@ GLOBAL							*fern-mapping-global*
 	DEPRECATED: Use |<Plug>(fern-action-hidden:toggle)| instead.
 
 *<Plug>(fern-action-include)*
+*<Plug>(fern-action-include=)*
 	Open a prompt to enter include filter. Users can type a |pattern| to
 	filter nodes recursively.
-
+	You can use a "=" variant to apply values to the prompt and/or submit
+	a value like:
+>
+	" Automatically apply "foo" to the prompt and submit.
+	nmap <buffer>
+	      \ <Plug>(my-include)
+	      \ <Plug>(fern-action-include=)foo<CR>
+<
 *<Plug>(fern-action-exclude)*
+*<Plug>(fern-action-exclude=)*
 	Open a prompt to enter exclude filter. Users can type a |pattern| to
 	filter nodes recursively.
-
+	You can use a "=" variant to apply values to the prompt and/or submit
+	a value like:
+>
+	" Automatically apply "foo" to the prompt and submit.
+	nmap <buffer>
+	      \ <Plug>(my-exclude)
+	      \ <Plug>(fern-action-exclude=)foo<CR>
+<
 *<Plug>(fern-action-mark:clear)*
 	Clear existing marks.
 
@@ -895,8 +911,16 @@ GLOBAL							*fern-mapping-global*
 	Collapse on a cursor node.
 
 *<Plug>(fern-action-reveal)*
+*<Plug>(fern-action-reveal=)*
 	Open a prompt to reveal a node in a tree.
-
+	You can use a "=" variant to apply values to the prompt and/or submit
+	a value like:
+>
+	" Automatically apply "foo" to the prompt and submit.
+	nmap <buffer>
+	      \ <Plug>(my-reveal)
+	      \ <Plug>(fern-action-reveal=)foo<CR>
+<
 *<Plug>(fern-action-focus:parent)*
 	Focus the parent of the cursor node.
 
@@ -1103,26 +1127,58 @@ FILE							*fern-mapping-file*
 The following mappings/actions are only available on file:// scheme.
 
 *<Plug>(fern-action-ex)*
+*<Plug>(fern-action-ex=)*
 	Open a prompt to execute an Ex command with a path of cursor node or 
 	paths of marked nodes.
-
+	You can use a "=" variant to apply values to the prompt and/or submit
+	a value like:
+>
+	" Automatically apply "foo" to the prompt and submit.
+	nmap <buffer>
+	      \ <Plug>(my-ex)
+	      \ <Plug>(fern-action-ex=)foo<CR>
+<
 *<Plug>(fern-action-new-path)*
+*<Plug>(fern-action-new-path=)*
 	Open a prompt to ask a path and create a file/directory of the input
 	path from the path of a cursor node.
 	Any intermediate directories of the destination will be created.
 	If the path ends with "/", it creates a directory. Otherwise it
 	creates a file.
-
+	You can use a "=" variant to apply values to the prompt and/or submit
+	a value like:
+>
+	" Automatically apply "foo" to the prompt and submit.
+	nmap <buffer>
+	      \ <Plug>(my-new-path)
+	      \ <Plug>(fern-action-new-path=)foo<CR>
+<
 *<Plug>(fern-action-new-file)*
+*<Plug>(fern-action-new-file=)*
 	Open a prompt to ask a path and create a file of the input path from
 	the path of a cursor node.
 	Any intermediate directories of the destination will be created.
-
+	You can use a "=" variant to apply values to the prompt and/or submit
+	a value like:
+>
+	" Automatically apply "foo" to the prompt and submit.
+	nmap <buffer>
+	      \ <Plug>(my-new-file)
+	      \ <Plug>(fern-action-new-file=)foo<CR>
+<
 *<Plug>(fern-action-new-dir)*
+*<Plug>(fern-action-new-dir=)*
 	Open a prompt to ask a path and create a directory of the input path 
 	from the path of a cursor node.
 	Any intermediate directories of the destination will be created.
-
+	You can use a "=" variant to apply values to the prompt and/or submit
+	a value like:
+>
+	" Automatically apply "foo" to the prompt and submit.
+	nmap <buffer>
+	      \ <Plug>(my-new-dir)
+	      \ <Plug>(fern-action-new-dir=)foo<CR>
+<
 *<Plug>(fern-action-copy)*
 	Open a prompt to ask a path and copy a file/directory of the cursor
 	node or marked node path(s) to the input path(s).
@@ -1195,9 +1251,17 @@ The following mappings/actions are only available on file:// scheme.
 	Note that this action has NO-relation with the system clipboard.
 
 *<Plug>(fern-action-grep)*
+*<Plug>(fern-action-grep=)*
 	Open a prompt to ask a grep pattern and execute grep command under the
 	cursor node. It respects the value of 'grepprg' and 'grepformat'.
-	
+	You can use a "=" variant to apply values to the prompt and/or submit
+	a value like:
+>
+	" Automatically apply "foo" to the prompt and submit.
+	nmap <buffer>
+	      \ <Plug>(my-grep)
+	      \ <Plug>(fern-action-grep=)foo<CR>
+<
 *<Plug>(fern-action-rename:select)*
 *<Plug>(fern-action-rename:split)*
 *<Plug>(fern-action-rename:vsplit)*


### PR DESCRIPTION
With this PR, users can provide mappings with default value like:

```vim
nmap <buffer> <Plug>(fern-action-dirdiff) <Plug>(fern-action-ex=)DirDiff<CR>
```

Above add `dirdiff` action which execute [`:DirDiff`](https://github.com/will133/vim-dirdiff) command on marked file scheme nodes.

https://user-images.githubusercontent.com/546312/124349770-d75f8d00-dc2b-11eb-9d77-8caf49d1762d.mp4

