### PR TITLE
Fix `E474: Invalid argument: cursorlineopt=number,line` in Neovim nightly

### DIFF
--- a/autoload/fern/internal/viewer/hide_cursor.vim
+++ b/autoload/fern/internal/viewer/hide_cursor.vim
@@ -17,6 +17,8 @@ function! s:hide_cursor_init() abort
 
   " Do NOT allow cursorlineopt=number while the cursor is hidden (Fix #182)
   if exists('+cursorlineopt')
-    setlocal cursorlineopt=number,line
+    " NOTE:
+    " Default value is `number,line` (or `both` prior to patch-8.1.2029)
+    setlocal cursorlineopt&
   endif
 endfunction


### PR DESCRIPTION
The `cursorlineopt` was introduced at patch 8.1.2019 but at that time, the
default value was `both` and `,` is not allowed in the value.
After patch 8.1.2029, `,` is allowed and the default value became `number,line`.

Neovim nightly (2021/08/01) raise E474 because https://github.com/neovim/neovim/pull/15161
only introduce patch 8.1.2019.

Thanks @yuki-yano 