### PR TITLE
Add universal fern feature

### DIFF
--- a/autoload/fern/internal/viewer.vim
+++ b/autoload/fern/internal/viewer.vim
@@ -80,10 +80,22 @@ function! s:init() abort
     throw printf('no such scheme %s exists', scheme)
   endif
 
-  let b:fern = fern#internal#core#new(
-        \ resource_uri,
-        \ provider,
-        \)
+  if !exists("g:fern") && !g:fern#disable_drawer_universal
+    let g:fern = fern#internal#core#new(
+          \ resource_uri,
+          \ provider,
+          \)
+  endif
+
+  if g:fern#disable_drawer_universal
+    let b:fern = fern#internal#core#new(
+          \ resource_uri,
+          \ provider,
+          \)
+  else
+    let b:fern = g:fern
+  endif  
+
   let helper = fern#helper#new()
   let root = helper.sync.get_root_node()
 

--- a/doc/fern.txt
+++ b/doc/fern.txt
@@ -457,6 +457,14 @@ VARIABLE						*fern-variable*
 <
 	Default: 0
 
+*g:fern#disable_drawer_universal*
+	Set 1 to disable universal drawer.
+
+        The universal drawer feature will run only one fern tree
+        across one vim instance.
+
+        Default: 1
+
 *g:fern#disable_drawer_auto_restore_focus*
 	Set 1 to disable automatic focus restore on drawer close.
 	The behavior changes like: (# indicate the cursor)


### PR DESCRIPTION
The universal fern feature is to allow users to share a single fern anywhere in the vim instance.

Issue: https://github.com/lambdalisue/fern.vim/issues/402