### PR TITLE
Fix failures to list self-referenced symlink

### DIFF
--- a/autoload/fern/scheme/file/util.vim
+++ b/autoload/fern/scheme/file/util.vim
@@ -24,7 +24,7 @@ endif
 if !s:is_windows && executable('find')
   function! fern#scheme#file#util#list_entries_find(path, token) abort
     let l:Profile = fern#profile#start('fern#scheme#file#util#list_entries_find')
-    return s:Process.start(['find', a:path, '-follow', '-maxdepth', '1'], { 'token': a:token, 'reject_on_failure': 1 })
+    return s:Process.start(['find', '-H', a:path, '-maxdepth', '1'], { 'token': a:token, 'reject_on_failure': 1 })
           \.catch({ v -> s:Promise.reject(join(v.stderr, "\n")) })
           \.then({ v -> v.stdout })
           \.then(s:AsyncLambda.filter_f({ v -> !empty(v) && v !=# a:path }))


### PR DESCRIPTION
Previous fern.vim can't list file entries containing even one self-referenced symlink because a `find` command invoked in the background emits an error such as `Too many levels of symbolic links` by the `-follow` option. The option tries to dereference symlinks in listing files. But we only need to dereference symlinks on the command line, but not dereference symlinks in listing files. So we should use the `-H` option, which doesn't dereference symlinks except on the command line, instead of the `-follow` option.

This problem happens on Linux, but not macOS. The `find` command installed in macOS by default doesn't emit errors in the situation above.

Fixes #384.