### PR TITLE
Map <Return> and <Backspace> directly to <Plug> commands

### DIFF
--- a/autoload/fern/mapping/node.vim
+++ b/autoload/fern/mapping/node.vim
@@ -21,12 +21,12 @@ function! fern#mapping#node#init(disable_default_mappings) abort
   if !a:disable_default_mappings
     nmap <buffer><nowait> <F5> <Plug>(fern-action-reload)
     nmap <buffer><nowait> <C-m> <Plug>(fern-action-enter)
+    nmap <buffer><nowait> <Return> <Plug>(fern-action-enter)
     nmap <buffer><nowait> <C-h> <Plug>(fern-action-leave)
+    nmap <buffer><nowait> <Backspace> <Plug>(fern-action-leave)
     nmap <buffer><nowait> l <Plug>(fern-action-expand)
     nmap <buffer><nowait> h <Plug>(fern-action-collapse)
     nmap <buffer><nowait> i <Plug>(fern-action-reveal)
-    nmap <buffer><nowait> <Return> <C-m>
-    nmap <buffer><nowait> <Backspace> <C-h>
   endif
 endfunction
 

--- a/autoload/fern/mapping/open.vim
+++ b/autoload/fern/mapping/open.vim
@@ -45,6 +45,7 @@ function! fern#mapping#open#init(disable_default_mappings) abort
 
   if !a:disable_default_mappings
     nmap <buffer><nowait> <C-m> <Plug>(fern-action-open-or-enter)
+    nmap <buffer><nowait> <Return> <Plug>(fern-action-open-or-enter)
     nmap <buffer><nowait> l <Plug>(fern-action-open-or-expand)
     nmap <buffer><nowait> s <Plug>(fern-action-open:select)
     nmap <buffer><nowait> e <Plug>(fern-action-open)


### PR DESCRIPTION
NeoVim introduced a breaking change that breaks indirect mapping of
`<Return>` and `<Backspace>` to a command via `<C-m>` and `<C-h>`.
(https://github.com/neovim/neovim/issues/14090#issuecomment-1113090354)

Mapping them directly fixes the problem and is clearer.