### PR TITLE
Proposal: Automatically resize all windows with drawer

### DIFF
--- a/autoload/fern.vim
+++ b/autoload/fern.vim
@@ -27,6 +27,7 @@ call s:Config.config(expand('<sfile>:p'), {
       \ 'disable_viewer_auto_duplication': 0,
       \ 'disable_drawer_auto_winfixwidth': 0,
       \ 'disable_drawer_auto_resize': 0,
+      \ 'disable_drawer_auto_resize_all': 1,
       \ 'disable_drawer_smart_quit': get(g:, 'disable_drawer_auto_quit', 0),
       \ 'disable_drawer_hover_popup': 0,
       \ 'disable_drawer_tabpage_isolation': 0,

--- a/autoload/fern/internal/drawer.vim
+++ b/autoload/fern/internal/drawer.vim
@@ -47,8 +47,9 @@ function! fern#internal#drawer#init() abort
     return
   endif
 
-  call fern#internal#drawer#auto_resize#init()
   call fern#internal#drawer#auto_winfixwidth#init()
+  call fern#internal#drawer#auto_resize#init()
+  call fern#internal#drawer#auto_resize_all#init()
   call fern#internal#drawer#auto_restore_focus#init()
   call fern#internal#drawer#smart_quit#init()
   call fern#internal#drawer#resize()
@@ -56,8 +57,6 @@ function! fern#internal#drawer#init() abort
   if !fern#internal#drawer#is_right_drawer()
     call fern#internal#drawer#hover_popup#init()
   endif
-
-  setlocal winfixwidth
 endfunction
 
 function! s:focus_next(right) abort

--- a/autoload/fern/internal/drawer/auto_resize_all.vim
+++ b/autoload/fern/internal/drawer/auto_resize_all.vim
@@ -1,0 +1,14 @@
+function! fern#internal#drawer#auto_resize_all#init() abort
+  if g:fern#disable_drawer_auto_resize_all
+    return
+  endif
+
+  augroup fern_internal_drawer_auto_resize_all_init
+    autocmd! * <buffer>
+    autocmd BufEnter <buffer> call s:resize_all()
+  augroup END
+endfunction
+
+function! s:resize_all() abort
+  execute "normal! \<C-W>="
+endfunction

--- a/doc/fern.txt
+++ b/doc/fern.txt
@@ -419,6 +419,13 @@ VARIABLE						*fern-variable*
 
 	Default: 0
 
+*g:fern#disable_drawer_auto_resize_all*
+	Set 1 to disable automatically resize all windows on |BufEnter| autocmd.
+	Note that this feature affects all windows except for drawer if
+        |g:fern#disable_drawer_auto_winfixwidth| is 1.
+
+	Default: 1
+
 *g:fern#disable_drawer_hover_popup*
 	Set 1 to disable popups shown when the name of a node extends beyond
 	the width of the drawer.


### PR DESCRIPTION
Currently, all windows except for drawer are not resized equally at opening with drawer.
This PR enables to resize all (or except for drawer) windows equally with `g:fern#disable_drawer_auto_resize_all = 0`.

And remove the following line by changing order to call init functions.
https://github.com/lambdalisue/fern.vim/blob/305d644413a2b9bb707e2c222161a34c363cdba6/autoload/fern/internal/drawer.vim#L60

If this feature is not responsible for Fern, please close this PR.