### PR TITLE
add <Plug>(fern-action-open:drop)

### DIFF
--- a/autoload/fern/mapping/open.vim
+++ b/autoload/fern/mapping/open.vim
@@ -13,6 +13,7 @@ function! fern#mapping#open#init(disable_default_mappings) abort
   nnoremap <buffer><silent> <Plug>(fern-action-open:leftest)  :<C-u>call <SID>call('open', 'topleft vsplit')<CR>
   nnoremap <buffer><silent> <Plug>(fern-action-open:bottom)   :<C-u>call <SID>call('open', 'botright split')<CR>
   nnoremap <buffer><silent> <Plug>(fern-action-open:rightest) :<C-u>call <SID>call('open', 'botright vsplit')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-open:drop)     :<C-u>call <SID>call('open', 'drop')<CR>
   nnoremap <buffer><silent> <Plug>(fern-action-open:edit-or-error)   :<C-u>call <SID>call('open', 'edit')<CR>
   nnoremap <buffer><silent> <Plug>(fern-action-open:edit-or-split)   :<C-u>call <SID>call('open', 'edit/split')<CR>
   nnoremap <buffer><silent> <Plug>(fern-action-open:edit-or-vsplit)  :<C-u>call <SID>call('open', 'edit/vsplit')<CR>

--- a/doc/fern.txt
+++ b/doc/fern.txt
@@ -929,6 +929,10 @@ GLOBAL							*fern-mapping-global*
 	The command will be applied on an "anchor" window when invoked from a
 	drawer style fern (|fern-glossary-anchor|.)
 
+*<Plug>(fern-action-open:drop)*
+	Open a cursor node or jump the window when it was already opend.
+	Note See |drop| for more details.
+
 *<Plug>(fern-action-open:edit-or-error)*
 	Open a cursor node or marked nodes with |edit| command or fallback
 	to print an error. 

--- a/test/fern/internal/buffer.vimspec
+++ b/test/fern/internal/buffer.vimspec
@@ -135,6 +135,22 @@ Describe fern#internal#buffer
             \ 'opener': 'vsplit',
             \})
       Assert Equals(winnr('$'), 2)
+      %bwipeout!
+
+      call fern#internal#buffer#open('hello1', {
+            \ 'opener': 'edit',
+            \})
+      call fern#internal#buffer#open('hello2', {
+            \ 'opener': 'vsplit',
+            \})
+      call fern#internal#buffer#open('hello1', {
+            \ 'opener': 'drop',
+            \})
+      Assert Equals(winnr(), 2)
+      call fern#internal#buffer#open('hello2', {
+            \ 'opener': 'drop',
+            \})
+      Assert Equals(winnr(), 1)
     End
   End
 End


### PR DESCRIPTION
## Issues

- https://github.com/lambdalisue/fern.vim/issues/362

## Why I did

I want to use the `:drop` command on fern.vim.

## What I did

I just added the mapping and its test.

Please teach me if I missed something to do 😉 