### PR TITLE
Fix 'E242' when smart-quit feature on Neovim 0.7.1

### DIFF
--- a/autoload/fern/internal/drawer/smart_quit.vim
+++ b/autoload/fern/internal/drawer/smart_quit.vim
@@ -30,11 +30,12 @@ function! s:smart_quit() abort
   elseif keep
     " Add a new window to avoid being a last window
     let winid = win_getid()
-    if has('nvim')
-      call s:complement(winid, width)
-    else
+    if has('patch-8.1.1756') || has('nvim-0.7.1')
       " Use timer to avoid E242 in Vim
+      " https://github.com/lambdalisue/fern.vim/issues/435
       call timer_start(0, { -> s:complement(winid, width) })
+    else
+      call s:complement(winid, width)
     endif
   else
     " This window is a last window of a current tabpage

--- a/test/behavior/drawer-smart-quit.vimspec
+++ b/test/behavior/drawer-smart-quit.vimspec
@@ -1,3 +1,9 @@
+if has('win32')
+  command! Relax sleep 100m
+else
+  command! Relax sleep 1m
+endif
+
 Describe drawer-smart-quit
   After all
     %bwipeout!
@@ -14,7 +20,7 @@ Describe drawer-smart-quit
       Fern . -drawer -keep -stay
       Assert Equals(winnr('$'), 2)
       quit
-      sleep 1m
+      Relax
       Assert Equals(winnr('$'), 2)
     End
 
@@ -23,7 +29,7 @@ Describe drawer-smart-quit
       Fern . -drawer -keep -stay
       Assert Equals(winnr('$'), 2)
       quit
-      sleep 1m
+      Relax
       Assert Equals(winnr('$'), 1)
     End
   End


### PR DESCRIPTION
Close #435 