### PR TITLE
Correct hover popup position on right side drawer

### DIFF
--- a/autoload/fern/internal/drawer.vim
+++ b/autoload/fern/internal/drawer.vim
@@ -51,11 +51,8 @@ function! fern#internal#drawer#init() abort
   call fern#internal#drawer#auto_winfixwidth#init()
   call fern#internal#drawer#auto_restore_focus#init()
   call fern#internal#drawer#smart_quit#init()
+  call fern#internal#drawer#hover_popup#init()
   call fern#internal#drawer#resize()
-
-  if !fern#internal#drawer#is_right_drawer()
-    call fern#internal#drawer#hover_popup#init()
-  endif
 
   setlocal winfixwidth
 endfunction

--- a/doc/fern.txt
+++ b/doc/fern.txt
@@ -424,9 +424,7 @@ VARIABLE						*fern-variable*
 	the width of the drawer.
 
 	Note that this feature is required the |win_execute| and
-	popup/floatwin features. 
-
-	Note that this feature is only available on a left-sided drawer.
+	popup/floatwin features.
 
 	Default: 0
 
@@ -531,7 +529,7 @@ VARIABLE						*fern-variable*
 	Default: "default"
 
 *g:fern#drawer_width*
-	A |Number| width of drawer in default.
+	A |Number|, the default width of the drawer window.
 	Default: 30
 
 *g:fern#drawer_keep*


### PR DESCRIPTION
When navigating through nodes in a drawer window, node names that extend beyond the width of the fern window are shown in a popup to display the full name to the user.

A regression introduced in 10dd4bb (Improve hover popup behavior, 2022-03-16) prevented the popup from being positioned correctly in drawer windows positioned on the right side. As a result, the hover popup behavior was disabled for right hand drawers in ab237a1 (Merge pull request #419 from lambdalisue/fix-popup-right, 2022-04-15).

This revision reintroduces this functionality, ensuring that the popup windows are positioned correctly in all cases.

Fixes https://github.com/lambdalisue/fern.vim/issues/418

# Notes
I haven't tested this in neovim. I don't use neovim myself, so any assistance would be hugely appreciated!

# Screenshots
![image](https://user-images.githubusercontent.com/22732449/195989595-54e15f6d-c917-43fe-8395-a188ab18669a.png)
Popup text doesn't wrap like it used to, which was an undeseriable quirk of the first revision of this feature.

![image](https://user-images.githubusercontent.com/22732449/195989632-6a8096a2-6829-478e-a43b-1860fff1d934.png)
Popup is not shown when the text fits in the window perfectly.

![image](https://user-images.githubusercontent.com/22732449/195989883-8ece5de0-40bd-47ec-b688-f13701061714.png)
Identical behaviour for left-handed drawer windows.
