### PR TITLE
renderer: fix syntax highlight for root symbol

### DIFF
--- a/autoload/fern/renderer/default.vim
+++ b/autoload/fern/renderer/default.vim
@@ -40,7 +40,7 @@ endfunction
 function! s:syntax() abort
   syntax match FernLeaf   /^.*[^/].*$/ transparent contains=FernLeafSymbol
   syntax match FernBranch /^.*\/.*$/   transparent contains=FernBranchSymbol
-  syntax match FernRoot   /\%1l.*/       transparent contains=FernRootText
+  syntax match FernRoot   /\%1l.*/       transparent contains=FernRootSymbol
   execute printf(
         \ 'syntax match FernRootSymbol /%s/ contained nextgroup=FernRootText',
         \ escape(g:fern#renderer#default#root_symbol, s:ESCAPE_PATTERN),

--- a/doc/fern-develop.txt
+++ b/doc/fern-develop.txt
@@ -561,7 +561,7 @@ nodes as a tree.
 	Return a promise which is resolved to a list of |String|.
 
 	Change (v1.6.0):~
-	Second argumet ({marks}) has removed.
+	Second argument ({marks}) has removed.
 
 					*fern-develop-renderer.index()*
 .index({lnum})


### PR DESCRIPTION
The syntax highlighting in the default renderer doesn't match the root node, meaning that any default or custom highlighting does not apply correctly. This has been corrected in this revision.