### PR TITLE
Remove noautocmd when open exists drawer

### DIFF
--- a/autoload/fern/internal/drawer.vim
+++ b/autoload/fern/internal/drawer.vim
@@ -67,6 +67,6 @@ function! s:focus_next(right) abort
   if winnr is# 0
     return
   endif
-  noautocmd call win_gotoid(win_getid(winnr))
+  call win_gotoid(win_getid(winnr))
   return 1
 endfunction


### PR DESCRIPTION
If the `Fern -drawer` command is executed again when Drawer is already open, WinLeave and WinEnter commands will not fire due to noautocmd.
This could be fixed and cause problems, but I'd like to try it in and see!