### PR TITLE
feat: add support for rendering text with props

### DIFF
--- a/autoload/fern.vim
+++ b/autoload/fern.vim
@@ -36,6 +36,7 @@ call s:Config.config(expand('<sfile>:p'), {
       \ 'default_exclude': '',
       \ 'renderer': 'default',
       \ 'renderers': {},
+      \ 'enable_textprop_support': 0,
       \ 'comparator': 'default',
       \ 'comparators': {},
       \ 'drawer_width': 30,

--- a/autoload/fern/internal/drawer/hover_popup.vim
+++ b/autoload/fern/internal/drawer/hover_popup.vim
@@ -74,7 +74,7 @@ function! s:show() abort
     call setbufline('%', 1, line)
     call helper.fern.renderer.syntax()
     call helper.fern.renderer.highlight()
-    syntax clear FernRoot
+    syntax clear FernRootSymbol
     syntax clear FernRootText
 
     setlocal nowrap cursorline noswapfile nobuflisted buftype=nofile bufhidden=hide

--- a/doc/fern-develop.txt
+++ b/doc/fern-develop.txt
@@ -558,7 +558,15 @@ nodes as a tree.
 
 					*fern-develop-renderer.render()*
 .render({nodes})
-	Return a promise which is resolved to a list of |String|.
+	Return a promise which is resolved to:
+
+	  a list of |String|, or
+	  if |g:fern#enable_textprop_support| is 1, a list of |Dictionary|
+		with the following entries:
+	    text  |String| with the text to display.
+	    props A list of text properties (|Dictionary|). Optional. Not supported
+	          for Neovim. Each entry is a dictionary, like the third argument
+	          of |prop_add()|, but specifying a column with a "col" entry.
 
 	Change (v1.6.0):~
 	Second argument ({marks}) has removed.

--- a/doc/fern.txt
+++ b/doc/fern.txt
@@ -523,6 +523,11 @@ VARIABLE						*fern-variable*
 	is a key of |g:fern#renderers|.
 	Default: "default"
 
+*g:fern#enable_textprop_support*
+	If set to 1, renderers may return lines of text with text properties.
+	May incur slight performance penalty. See |fern-develop-renderer|.
+	Default: 0
+
 *g:fern#comparator*
 	A |String| name of comparator used to sort tree items. Allowed value
 	is a key of |g:fern#comparators|.

--- a/test/fern/internal/buffer.vimspec
+++ b/test/fern/internal/buffer.vimspec
@@ -5,6 +5,16 @@ Describe fern#internal#buffer
 
   Before
     %bwipeout!
+    if !has('nvim')
+      call prop_type_add('test_prop', { 'highlight': 'Question' })
+    endif
+  End
+
+  After
+    let g:fern#enable_textprop_support = 0
+    if !has('nvim')
+      call prop_type_delete('test_prop')
+    endif
   End
 
   Describe #replace()
@@ -114,6 +124,45 @@ Describe fern#internal#buffer
             \ "World",
             \])
       Assert Equals(getbufvar(bufnr, '&modified'), 1)
+    End
+
+    It should replace buffer content with text and properties
+      if has('nvim')
+        Assert Skip('text properties are only supported in vim')
+      endif
+
+      let g:fern#enable_textprop_support = 1
+
+      let bufnr = bufnr('%')
+      call setline(1, [
+            \ "Hello",
+            \ "Darkness",
+            \ "My",
+            \ "Old",
+            \ "Friend",
+            \])
+      new
+      call fern#internal#buffer#replace(bufnr, [
+            \ { 'text': 'Empty Props', 'props': [] },
+            \ { 'text': 'Undefined Props' },
+            \ { 'text': 'With Properties!', 'props':
+            \   [{ 'col': 1, 'length': 4, 'type': 'test_prop' }]
+            \ },
+            \])
+      Assert Equals(getbufline(bufnr, 1, '$'), [
+            \ "Empty Props",
+            \ "Undefined Props",
+            \ "With Properties!",
+            \])
+
+      Assert True(empty(prop_list(1, { 'bufnr': bufnr })))
+      Assert True(empty(prop_list(2, { 'bufnr': bufnr })))
+
+      let result_props = prop_list(3, { 'bufnr': bufnr })
+      Assert Equal(len(result_props), 1)
+      Assert Equal(result_props[0].col, 1)
+      Assert Equal(result_props[0].length, 4)
+      Assert Equal(result_props[0].type, 'test_prop')
     End
   End
 


### PR DESCRIPTION
Introduce the ability to render text with attached text properties. Renderers may now return list of dictionaries where each line of text can include text properties for additional text styling capabilities. This change is backwards compatible with existing renderers; they will continue to work as before.

The semantics of this feature was inspired by popup_create(), which can accept a list of dictionaries with a 'text' and 'props' key.

This feature enhances the capabilities of custom renderers. In particular, it's possible to implement renderers that render content with dynamically-defined style. The screenshot below shows a simple custom renderer that renders vim files in green, config files in grey and others in orange.

![image](https://user-images.githubusercontent.com/22732449/219378808-bbffaf55-0425-4c53-940e-50dcd1f14ac4.png)

Here's a renderer I built using these features: [brandon1024/fern-renderer-nf.vim](https://github.com/brandon1024/fern-renderer-nf.vim/blob/main/autoload/fern/renderer/nf.vim)

A very dumb renderer example:

```vim
" Build and return the renderer.
function! fern#renderer#nf#new() abort
        return {
		\ 'render': funcref('s:render'),
		\ 'index': { lnum -> lnum - 1 },
		\ 'lnum': { index -> index + 1 },
		\ 'syntax': { -> v:null },
		\ 'highlight': { -> v:null }
	\ }
endfunction

" Render given nodes and return a list of lines with text properties.
function! s:render(nodes) abort
	let l:base = len(a:nodes[0].__key)

	if empty(prop_type_get('test'))
		call prop_type_add('test', { 'highlight': 'Normal' })
	endif

	return map(copy(a:nodes), { i, node ->
		\ {
			\ 'text': '>' . repeat(' ', len(node.__key) - l:base) . node.label,
			\ 'type': [{ 'col': 1, 'length': 1, 'type': 'test' }]
		\ }})
endfunction
```
