### PR TITLE
Add action to open a subtree recursively

### DIFF
--- a/autoload/fern/helper/async.vim
+++ b/autoload/fern/helper/async.vim
@@ -179,7 +179,7 @@ function! s:async_expand_tree(key) abort dict
         \   fern.source.token,
         \ )
         \})
-        \.then({ _ -> self.update_nodes(fern.nodes) })
+        \.then({ ns -> self.update_nodes(ns) })
         \.finally({ -> Profile() })
 endfunction
 let s:async.expand_tree = funcref('s:async_expand_tree')

--- a/autoload/fern/helper/async.vim
+++ b/autoload/fern/helper/async.vim
@@ -156,6 +156,34 @@ function! s:async_expand_node(key) abort dict
 endfunction
 let s:async.expand_node = funcref('s:async_expand_node')
 
+function! s:async_expand_tree(key) abort dict
+  let helper = self.helper
+  let fern = helper.fern
+  let node = fern#internal#node#find(a:key, fern.nodes)
+  if empty(node)
+    return s:Promise.reject(printf('failed to find a node %s', a:key))
+  elseif node.status is# helper.STATUS_NONE
+    " To improve UX, reload owner instead
+    return self.reload_node(node.__owner.__key)
+  elseif node.status is# helper.STATUS_EXPANDED
+    " To improve UX, reload instead
+    return self.reload_node(node.__key)
+  endif
+  let l:Profile = fern#profile#start('fern#helper:helper.async.expand_tree')
+  return s:Promise.resolve()
+        \.then({ -> fern#internal#node#expand_tree(
+        \   node,
+        \   fern.nodes,
+        \   fern.provider,
+        \   fern.comparator,
+        \   fern.source.token,
+        \ )
+        \})
+        \.then({ _ -> self.update_nodes(fern.nodes) })
+        \.finally({ -> Profile() })
+endfunction
+let s:async.expand_tree = funcref('s:async_expand_tree')
+
 function! s:async_collapse_node(key) abort dict
   let helper = self.helper
   let fern = helper.fern

--- a/autoload/fern/internal/node.vim
+++ b/autoload/fern/internal/node.vim
@@ -236,6 +236,7 @@ function! s:extend(key, nodes, new_nodes) abort
 endfunction
 
 function! s:expand_recursively(index, key, nodes, provider, comparator, token) abort
+  echom "Lookie here:" a:nodes
   let node = fern#internal#node#find(a:key[:a:index], a:nodes)
   if node is# v:null || node.status is# s:STATUS_NONE
     return s:Promise.resolve(a:nodes)
@@ -246,4 +247,16 @@ function! s:expand_recursively(index, key, nodes, provider, comparator, token) a
         \   { -> s:expand_recursively(a:index + 1, a:key, ns, a:provider, a:comparator, a:token) },
         \   { -> ns },
         \ )})
+endfunction
+
+function! fern#internal#node#expand_tree(node, nodes, provider, comparator, token) abort
+  if a:node is# v:null || a:node.status is# s:STATUS_NONE
+    return s:Promise.resolve(a:nodes)
+  endif
+  " Expand the node
+  return fern#internal#node#expand(a:node, a:nodes, a:provider, a:comparator, a:token)
+        \.then({ -> fern#internal#node#children(a:node, a:provider, a:token) })
+        \.then(s:AsyncLambda.map_f({child_node -> fern#internal#node#expand_tree(child_node, a:nodes, a:provider, a:comparator, a:token)}))
+        \.then({ subtrees -> s:Promise.all(subtrees)})
+
 endfunction

--- a/autoload/fern/internal/node.vim
+++ b/autoload/fern/internal/node.vim
@@ -248,7 +248,6 @@ function! s:extend(key, nodes, new_nodes) abort
 endfunction
 
 function! s:expand_recursively(index, key, nodes, provider, comparator, token) abort
-  echom "Lookie here:" a:nodes
   let node = fern#internal#node#find(a:key[:a:index], a:nodes)
   if node is# v:null || node.status is# s:STATUS_NONE
     return s:Promise.resolve(a:nodes)

--- a/autoload/fern/internal/node.vim
+++ b/autoload/fern/internal/node.vim
@@ -135,7 +135,6 @@ function! fern#internal#node#expand_tree(node, nodes, provider, comparator, toke
   if a:node is# v:null || a:node.status is# s:STATUS_NONE
     return s:Promise.resolve(a:nodes)
   endif
-  " Expand the node
   return fern#internal#node#expand(a:node, a:nodes, a:provider, a:comparator, a:token)
         \.then({ -> fern#internal#node#children(a:node, a:provider, a:token) })
         \.then(s:AsyncLambda.map_f({child_node -> fern#internal#node#expand_tree(child_node, a:nodes, a:provider, a:comparator, a:token)}))

--- a/autoload/fern/internal/node.vim
+++ b/autoload/fern/internal/node.vim
@@ -131,6 +131,18 @@ function! fern#internal#node#expand(node, nodes, provider, comparator, token) ab
   return p
 endfunction
 
+function! fern#internal#node#expand_tree(node, nodes, provider, comparator, token) abort
+  if a:node is# v:null || a:node.status is# s:STATUS_NONE
+    return s:Promise.resolve(a:nodes)
+  endif
+  " Expand the node
+  return fern#internal#node#expand(a:node, a:nodes, a:provider, a:comparator, a:token)
+        \.then({ -> fern#internal#node#children(a:node, a:provider, a:token) })
+        \.then(s:AsyncLambda.map_f({child_node -> fern#internal#node#expand_tree(child_node, a:nodes, a:provider, a:comparator, a:token)}))
+        \.then({ subtrees -> s:Promise.all(subtrees)})
+
+endfunction
+
 function! fern#internal#node#collapse(node, nodes, provider, comparator, token) abort
   if a:node.status is# s:STATUS_NONE
     return s:Promise.reject('cannot collapse leaf node')
@@ -247,16 +259,4 @@ function! s:expand_recursively(index, key, nodes, provider, comparator, token) a
         \   { -> s:expand_recursively(a:index + 1, a:key, ns, a:provider, a:comparator, a:token) },
         \   { -> ns },
         \ )})
-endfunction
-
-function! fern#internal#node#expand_tree(node, nodes, provider, comparator, token) abort
-  if a:node is# v:null || a:node.status is# s:STATUS_NONE
-    return s:Promise.resolve(a:nodes)
-  endif
-  " Expand the node
-  return fern#internal#node#expand(a:node, a:nodes, a:provider, a:comparator, a:token)
-        \.then({ -> fern#internal#node#children(a:node, a:provider, a:token) })
-        \.then(s:AsyncLambda.map_f({child_node -> fern#internal#node#expand_tree(child_node, a:nodes, a:provider, a:comparator, a:token)}))
-        \.then({ subtrees -> s:Promise.all(subtrees)})
-
 endfunction

--- a/autoload/fern/internal/node.vim
+++ b/autoload/fern/internal/node.vim
@@ -140,7 +140,7 @@ function! fern#internal#node#expand_tree(node, nodes, provider, comparator, toke
         \.then({ -> fern#internal#node#children(a:node, a:provider, a:token) })
         \.then(s:AsyncLambda.map_f({child_node -> fern#internal#node#expand_tree(child_node, a:nodes, a:provider, a:comparator, a:token)}))
         \.then({ subtrees -> s:Promise.all(subtrees)})
-
+        \.then({ -> a:nodes })
 endfunction
 
 function! fern#internal#node#collapse(node, nodes, provider, comparator, token) abort

--- a/autoload/fern/internal/node.vim
+++ b/autoload/fern/internal/node.vim
@@ -133,16 +133,18 @@ endfunction
 
 function! fern#internal#node#expand_tree(node, nodes, provider, comparator, token) abort
   if a:node is# v:null || a:node.status is# s:STATUS_NONE
-    return s:Promise.reject("cannot expand a leaf node")
+    return s:Promise.reject('cannot expand a leaf node')
   endif
   let l:state = {}
+  let l:Done = fern#internal#node#process(a:node)
   return fern#internal#node#expand(a:node, a:nodes, a:provider, a:comparator, a:token)
         \.then({ns -> s:Lambda.let(state, 'ns', ns)})
         \.then({ -> fern#internal#node#children(a:node, a:provider, a:token) })
-        \.then(s:AsyncLambda.filter_f({child -> child isnot# v:null && child.status isnot# s:STATUS_NONE}))
-        \.then(s:AsyncLambda.map_f({child_node -> fern#internal#node#expand_tree(child_node, state.ns, a:provider, a:comparator, a:token)}))
-        \.then({ subtree_promises -> s:Promise.all(subtree_promises)})
-        \.then({ -> state.ns })
+        \.then(s:AsyncLambda.filter_f({ child -> child isnot# v:null && child.status isnot# s:STATUS_NONE }))
+        \.then(s:AsyncLambda.map_f({child_node -> fern#internal#node#expand_tree(child_node, state.ns, a:provider, a:comparator, a:token) }))
+        \.then({ subtree_promises -> s:Promise.all(subtree_promises) })
+        \.then({ -> l:state.ns })
+        \.finally({ -> Done() })
 endfunction
 
 function! fern#internal#node#collapse(node, nodes, provider, comparator, token) abort

--- a/autoload/fern/internal/node.vim
+++ b/autoload/fern/internal/node.vim
@@ -133,10 +133,11 @@ endfunction
 
 function! fern#internal#node#expand_tree(node, nodes, provider, comparator, token) abort
   if a:node is# v:null || a:node.status is# s:STATUS_NONE
-    return s:Promise.resolve(a:nodes)
+    return s:Promise.reject("cannot expand a leaf node")
   endif
   return fern#internal#node#expand(a:node, a:nodes, a:provider, a:comparator, a:token)
         \.then({ -> fern#internal#node#children(a:node, a:provider, a:token) })
+        \.then(s:AsyncLambda.filter_f({child -> child isnot# v:null && child.status isnot# s:STATUS_NONE}))
         \.then(s:AsyncLambda.map_f({child_node -> fern#internal#node#expand_tree(child_node, a:nodes, a:provider, a:comparator, a:token)}))
         \.then({ subtrees -> s:Promise.all(subtrees)})
         \.then({ -> a:nodes })

--- a/autoload/fern/internal/node.vim
+++ b/autoload/fern/internal/node.vim
@@ -135,12 +135,14 @@ function! fern#internal#node#expand_tree(node, nodes, provider, comparator, toke
   if a:node is# v:null || a:node.status is# s:STATUS_NONE
     return s:Promise.reject("cannot expand a leaf node")
   endif
+  let l:state = {}
   return fern#internal#node#expand(a:node, a:nodes, a:provider, a:comparator, a:token)
+        \.then({ns -> s:Lambda.let(state, 'ns', ns)})
         \.then({ -> fern#internal#node#children(a:node, a:provider, a:token) })
         \.then(s:AsyncLambda.filter_f({child -> child isnot# v:null && child.status isnot# s:STATUS_NONE}))
-        \.then(s:AsyncLambda.map_f({child_node -> fern#internal#node#expand_tree(child_node, a:nodes, a:provider, a:comparator, a:token)}))
-        \.then({ subtrees -> s:Promise.all(subtrees)})
-        \.then({ -> a:nodes })
+        \.then(s:AsyncLambda.map_f({child_node -> fern#internal#node#expand_tree(child_node, state.ns, a:provider, a:comparator, a:token)}))
+        \.then({ subtree_promises -> s:Promise.all(subtree_promises)})
+        \.then({ -> state.ns })
 endfunction
 
 function! fern#internal#node#collapse(node, nodes, provider, comparator, token) abort

--- a/autoload/fern/mapping/node.vim
+++ b/autoload/fern/mapping/node.vim
@@ -121,12 +121,12 @@ function! s:map_expand_tree_in(helper) abort
     return s:Promise.reject('no node found on a cursor line')
   endif
   let previous = a:helper.sync.get_cursor_node()
+  let old_size = len(a:helper.fern.nodes)
   return a:helper.async.expand_tree(node.__key)
         \.then({ -> a:helper.async.redraw() })
-        \.then({ -> a:helper.async.get_child_nodes(node.__key) })
         \.then({ c -> a:helper.sync.focus_node(
         \   node.__key,
-        \   { 'previous': previous, 'offset': len(c) > 0 },
+        \   { 'previous': previous, 'offset': len(a:helper.fern.nodes) != old_size },
         \ )
         \})
 endfunction

--- a/autoload/fern/mapping/node.vim
+++ b/autoload/fern/mapping/node.vim
@@ -121,14 +121,12 @@ function! s:map_expand_tree_in(helper) abort
     return s:Promise.reject('no node found on a cursor line')
   endif
   let previous = a:helper.sync.get_cursor_node()
-  let ns = {}
   return a:helper.async.expand_tree(node.__key)
         \.then({ -> a:helper.async.redraw() })
         \.then({ -> a:helper.async.get_child_nodes(node.__key) })
-        \.then({ c -> s:Lambda.let(ns, 'offset', len(c) > 0) })
-        \.then({ -> a:helper.sync.focus_node(
+        \.then({ c -> a:helper.sync.focus_node(
         \   node.__key,
-        \   { 'previous': previous, 'offset': ns.offset },
+        \   { 'previous': previous, 'offset': len(c) > 0 },
         \ )
         \})
 endfunction

--- a/autoload/fern/mapping/node.vim
+++ b/autoload/fern/mapping/node.vim
@@ -2,20 +2,20 @@ let s:Promise = vital#fern#import('Async.Promise')
 let s:Lambda = vital#fern#import('Lambda')
 
 function! fern#mapping#node#init(disable_default_mappings) abort
-  nnoremap <buffer><silent> <Plug>(fern-action-debug)         :<C-u>call <SID>call('debug')<CR>
-  nnoremap <buffer><silent> <Plug>(fern-action-reload:all)    :<C-u>call <SID>call('reload_all')<CR>
-  nnoremap <buffer><silent> <Plug>(fern-action-reload:cursor) :<C-u>call <SID>call('reload_cursor')<CR>
-  nnoremap <buffer><silent> <Plug>(fern-action-expand:stay)   :<C-u>call <SID>call('expand_stay')<CR>
-  nnoremap <buffer><silent> <Plug>(fern-action-expand:in)     :<C-u>call <SID>call('expand_in')<CR>
-  nnoremap <buffer><silent> <Plug>(fern-action-expand-recursive:stay)   :<C-u>call <SID>call('expand_recursive_stay')<CR>
-  nnoremap <buffer><silent> <Plug>(fern-action-expand-recursive:in)     :<C-u>call <SID>call('expand_recursive_in')<CR>
-  nnoremap <buffer><silent> <Plug>(fern-action-collapse)      :<C-u>call <SID>call('collapse')<CR>
-  nnoremap <buffer><silent> <Plug>(fern-action-reveal)        :<C-u>call <SID>call('reveal')<CR>
-  nnoremap <buffer><silent> <Plug>(fern-action-reveal=)       :<C-u>call <SID>call_without_guard('reveal')<CR>
-  nnoremap <buffer><silent> <Plug>(fern-action-focus:parent)  :<C-u>call <SID>call('focus_parent')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-debug)            :<C-u>call <SID>call('debug')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-reload:all)       :<C-u>call <SID>call('reload_all')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-reload:cursor)    :<C-u>call <SID>call('reload_cursor')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-expand:stay)      :<C-u>call <SID>call('expand_stay')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-expand:in)        :<C-u>call <SID>call('expand_in')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-expand-tree:stay) :<C-u>call <SID>call('expand_tree_stay')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-expand-tree:in)   :<C-u>call <SID>call('expand_tree_in')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-collapse)         :<C-u>call <SID>call('collapse')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-reveal)           :<C-u>call <SID>call('reveal')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-reveal=)          :<C-u>call <SID>call_without_guard('reveal')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-focus:parent)     :<C-u>call <SID>call('focus_parent')<CR>
 
-  nnoremap <buffer><silent> <Plug>(fern-action-enter)         :<C-u>call <SID>call('enter')<CR>
-  nnoremap <buffer><silent> <Plug>(fern-action-leave)         :<C-u>call <SID>call('leave')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-enter)            :<C-u>call <SID>call('enter')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-leave)            :<C-u>call <SID>call('leave')<CR>
 
   nmap <buffer> <Plug>(fern-action-reload) <Plug>(fern-action-reload:all)
   nmap <buffer> <Plug>(fern-action-expand) <Plug>(fern-action-expand:in)
@@ -99,7 +99,7 @@ function! s:map_expand_in(helper) abort
         \})
 endfunction
 
-function! s:map_expand_recursive_stay(helper) abort
+function! s:map_expand_tree_stay(helper) abort
   let node = a:helper.sync.get_cursor_node()
   if node is# v:null
     return s:Promise.reject('no node found on a cursor line')
@@ -114,7 +114,7 @@ function! s:map_expand_recursive_stay(helper) abort
         \})
 endfunction
 
-function! s:map_expand_recursive_in(helper) abort
+function! s:map_expand_tree_in(helper) abort
   let node = a:helper.sync.get_cursor_node()
   if node is# v:null
     return s:Promise.reject('no node found on a cursor line')

--- a/autoload/fern/mapping/node.vim
+++ b/autoload/fern/mapping/node.vim
@@ -19,6 +19,7 @@ function! fern#mapping#node#init(disable_default_mappings) abort
 
   nmap <buffer> <Plug>(fern-action-reload) <Plug>(fern-action-reload:all)
   nmap <buffer> <Plug>(fern-action-expand) <Plug>(fern-action-expand:in)
+  nmap <buffer> <Plug>(fern-action-expand-tree) <Plug>(fern-action-expand-tree:in)
 
   if !a:disable_default_mappings
     nmap <buffer><nowait> <F5> <Plug>(fern-action-reload)

--- a/autoload/fern/mapping/node.vim
+++ b/autoload/fern/mapping/node.vim
@@ -123,9 +123,9 @@ function! s:map_expand_tree_in(helper) abort
   let previous = a:helper.sync.get_cursor_node()
   let ns = {}
   return a:helper.async.expand_tree(node.__key)
+        \.then({ -> a:helper.async.redraw() })
         \.then({ -> a:helper.async.get_child_nodes(node.__key) })
         \.then({ c -> s:Lambda.let(ns, 'offset', len(c) > 0) })
-        \.then({ -> a:helper.async.redraw() })
         \.then({ -> a:helper.sync.focus_node(
         \   node.__key,
         \   { 'previous': previous, 'offset': ns.offset },

--- a/doc/fern.txt
+++ b/doc/fern.txt
@@ -909,6 +909,20 @@ GLOBAL							*fern-mapping-global*
 	      \ <Plug>(fern-action-expand)
 	      \ <Plug>(fern-action-expand:stay)
 <
+*<Plug>(fern-action-expand-tree:stay)*
+	Expand the tree on a cursor node and keep the cursor on the root node.
+
+*<Plug>(fern-action-expand-tree:in)*
+	Expand the tree on a cursor node and keep the cursor on the root node
+        (moves to the first child node after the cursor node)
+
+*<Plug>(fern-action-expand-tree)*
+	An alias to "expand-tree:in" action. Users can overwrite this mapping to
+	change the default behavior of "expand-tree" action like:
+>
+	nmap <buffer>
+	      \ <Plug>(fern-action-expand-tree)
+	      \ <Plug>(fern-action-expand-tree:stay)
 
 *<Plug>(fern-action-collapse)*
 	Collapse on a cursor node.

--- a/doc/fern.txt
+++ b/doc/fern.txt
@@ -910,11 +910,12 @@ GLOBAL							*fern-mapping-global*
 	      \ <Plug>(fern-action-expand:stay)
 <
 *<Plug>(fern-action-expand-tree:stay)*
-	Expand the tree on a cursor node and keep the cursor on the root node.
+	Recursively expand the tree on a cursor node and keep the cursor on the
+	root node.
 
 *<Plug>(fern-action-expand-tree:in)*
-	Expand the tree on a cursor node and keep the cursor on the root node
-        (moves to the first child node after the cursor node)
+	Recursively expand the tree on a cursor node and keep the cursor on the 
+	root node (moves to the first child node after the cursor node)
 
 *<Plug>(fern-action-expand-tree)*
 	An alias to "expand-tree:in" action. Users can overwrite this mapping to

--- a/test/fern/internal/node.vimspec
+++ b/test/fern/internal/node.vimspec
@@ -168,6 +168,41 @@ Describe fern#internal#node
     End
   End
 
+  Describe #expand_tree()
+    Before
+      let root = fern#internal#node#root('debug:///', provider)
+    End
+
+    It returns a promise
+      let p = fern#internal#node#expand_tree(root, [root], provider, Comparator, token)
+      Assert True(Promise.is_promise(p))
+    End
+
+    It resolves to a list of nodes
+      let [r, e] = Promise.wait(
+            \ fern#internal#node#expand_tree(root, [root], provider, Comparator, token),
+            \ { 'timeout': TIMEOUT },
+            \)
+
+      Assert Equals(e, v:null)
+      Assert Equals(len(r), 14)
+      Assert Equals(r[0]._uri, '/')
+      Assert Equals(r[1]._uri, '/deep')
+      Assert Equals(r[2]._uri, '/deep/alpha')
+      Assert Equals(r[3]._uri, '/deep/alpha/beta')
+      Assert Equals(r[4]._uri, '/deep/alpha/beta/gamma')
+      Assert Equals(r[5]._uri, '/heavy')
+      Assert Equals(r[6]._uri, '/heavy/alpha')
+      Assert Equals(r[7]._uri, '/heavy/beta')
+      Assert Equals(r[8]._uri, '/heavy/gamma')
+      Assert Equals(r[9]._uri, '/shallow')
+      Assert Equals(r[10]._uri, '/shallow/alpha')
+      Assert Equals(r[11]._uri, '/shallow/beta')
+      Assert Equals(r[12]._uri, '/shallow/gamma')
+      Assert Equals(r[13]._uri, '/leaf')
+    End
+  End
+
   Describe #collapse()
     Before
       let root = fern#internal#node#root('debug:///', provider)


### PR DESCRIPTION
Opening entire subtrees is incredibly nice to have. Seeing as this hasn't been implemented due to [the difficulty of implementation](https://github.com/lambdalisue/fern.vim/issues/39#issuecomment-672146888), I decided to take a stab at it.

This fixes at least #39, #320, and #412.

---

The current state of the PR:

* `in` and `stay` both work (in a bare minimum proof-of-concept-type way; take that with a truckload of salt)
* `<Plug>` maps have been added and documented (or at least their existence is mentioned in the docs; only did half a glance at the docs, not sure if they need to be mentioned elsewhere)
* There's a single test pair in the `node.vimspec` file. I assume more tests would be nice, ~~but I haven't looked extensively, so not sure where they'd go~~ but I'm not seeing any equivalent tests that I can copy-pasta and modify. I can still add some if desired

Currently, the PR is a draft, because there are a couple problems that I can't quite deal with on my own:

1. Using `s:Promise.all` to merge the subtree promises feels like a hack, but I'm not seeing any obviously better options in vital.vim for dealing with arrays of promises. There's also plenty of discarded values, in part because `a:nodes` appears to be mutated, so just directly returning it is convenient. I'm not sure if this means the entire tree is refreshed, or if it's just some convenient abstraction representing change.
    * If the return values have to be used (rather than relying on `a:nodes`' mutability), the implementation complexity goes up considerably, particularly when it's time to merge the return values. I can store and return `ns` (whatever that is anyway) from `expand`, but the difficulty lies in merging a list of other `ns`es into the current `ns`. A very, very quick and shallow search only found a method that adds  a single node to `a:nodes`, and not one that trivially merges two `a:nodes` lists together. I could make one, but I opted not to when `a:nodes` is mutable, and there might be an even better approach that makes the entire thing pointless
2. There aren't any default keys set for the new actions. This is largely because I don't know what standards make sense, as I use my own keys in my config that more closely align with NERDTree than fern. Might also be an idea to do that separately from this PR

There's probably more stuff to grill in a code review as well (including bugs to be found; I do suspect using `a:nodes` instead of `ns` return values is something that'll come back to haunt me, but I haven't found anything obvious yet). A chunk of the implementation was based on existing functions (particularly the convenient `s:expand_recursively` that I shamelessly copy-pasta'd for a starting point), so there's probably a fair share of copy-pasta errors and redundancies as well

