### PR TITLE
Add "enter-to-leave" on root node feature by default

### DIFF
--- a/autoload/fern.vim
+++ b/autoload/fern.vim
@@ -24,6 +24,7 @@ call s:Config.config(expand('<sfile>:p'), {
       \ 'disable_auto_buffer_delete': 0,
       \ 'disable_auto_buffer_rename': 0,
       \ 'disable_default_mappings': 0,
+      \ 'disable_enter_to_leave_on_root': 0,
       \ 'disable_viewer_spinner': has('win32') && !has('gui_running'),
       \ 'disable_viewer_auto_duplication': 0,
       \ 'disable_drawer_auto_winfixwidth': 0,

--- a/autoload/fern/mapping/node.vim
+++ b/autoload/fern/mapping/node.vim
@@ -173,7 +173,11 @@ function! s:map_enter(helper) abort
   if node is# v:null
     return s:Promise.reject('no node found on a cursor line')
   endif
-  return a:helper.async.enter_tree(node)
+  if g:fern#disable_enter_to_leave_on_root || !empty(node.__owner)
+    return a:helper.async.enter_tree(node)
+  else
+    return a:helper.async.leave_tree()
+  endif
 endfunction
 
 function! s:map_leave(helper) abort

--- a/doc/fern.txt
+++ b/doc/fern.txt
@@ -567,6 +567,11 @@ VARIABLE						*fern-variable*
 	A |Number| value that specifies whether to synchronize file renames to the buffer
 	Default: 0
 
+*g:fern#disable_enter_to_leave_on_root*
+	A |Boolean| to disable "enter to leave" behavior on the root node.
+	If set to 1, "enter" on the root node will reload the tree instead.
+	Default: 0
+
 *g:fern#window_selector_use_popup*
 	A |Boolean| which use popup/float window to select window.
 	See |fern-glossary-window-selector|


### PR DESCRIPTION
Close #496

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration option to control the "enter to leave" behavior on the root node of the tree, enhancing navigation flexibility.

- **Documentation**
	- Documented the addition of a global variable for controlling tree navigation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->