### PR TITLE
Add `fern#smart#root()` for smart mapping of root node and others

### DIFF
--- a/autoload/fern/smart.vim
+++ b/autoload/fern/smart.vim
@@ -36,3 +36,14 @@ function! fern#smart#scheme(default, schemes) abort
   endif
   return a:default
 endfunction
+
+function! fern#smart#root(root, others) abort
+  let helper = fern#helper#new()
+  let node = helper.sync.get_cursor_node()
+  if node is# v:null
+    return "\<Nop>"
+  endif
+  return node.__owner is# v:null
+        \ ? a:root
+        \ : a:others
+endfunction

--- a/doc/fern.txt
+++ b/doc/fern.txt
@@ -222,6 +222,9 @@ Fern provide following mapping helper functions:
 	|fern#smart#scheme()|	Return a mapping expression determined by a
 				scheme of a current fern tree
 
+	|fern#smart#root()|	Return a mapping expression determined by a
+				kind of a current cursor node
+
 For example, following execute "open" on leaf but "expand" on branch.
 >
 	nmap <buffer><expr> <Plug>(fern-my-open-or-expand)

--- a/doc/fern.txt
+++ b/doc/fern.txt
@@ -714,7 +714,7 @@ fern#smart#scheme({default}, {schemes})
 fern#smart#root({root}, {others})
 	Return one of a given mapping expression determined by a kind of a
 	current cursor node. If the node is root, the {root} is returned.
-	Otehrwise the {others} is returned.
+	Otherwise the {others} is returned.
 >
 	" Perform 'leave' on root node and 'open-or-enter' on others
 	nmap <buffer><expr>

--- a/doc/fern.txt
+++ b/doc/fern.txt
@@ -686,7 +686,7 @@ fern#smart#drawer({drawer}, {drawer-right}, {explorer})
 >
 	" Perform 'expand' on drawer and 'enter' on explorer
 	nmap <buffer><expr>
-	      \ <Plug>(fern-expand-or-enter)
+	      \ <Plug>(fern-my-expand-or-enter)
 	      \ fern#smart#drawer(
 	      \   "<Plug>(fern-action-expand)",
 	      \   "<Plug>(fern-action-enter)",
@@ -708,6 +708,20 @@ fern#smart#scheme({default}, {schemes})
 	      \   {
 	      \     'bookmark': "\<C-^>",
 	      \   },
+	      \ )
+
+							*fern#smart#root()*
+fern#smart#root({root}, {others})
+	Return one of a given mapping expression determined by a kind of a
+	current cursor node. If the node is root, the {root} is returned.
+	Otehrwise the {others} is returned.
+>
+	" Perform 'leave' on root node and 'open-or-enter' on others
+	nmap <buffer><expr>
+	      \ <Plug>(fern-my-leave-or-open-or-enter)
+	      \ fern#smart#root(
+	      \   "<Plug>(fern-action-leave)",
+	      \   "<Plug>(fern-action-open-or-enter)",
 	      \ )
 
 -----------------------------------------------------------------------------


### PR DESCRIPTION
From #119

For example, users can define smart mapping for root node like

```vim
" Perform 'leave' on root node and 'open-or-enter' on others
nmap <buffer><expr>
      \ <Plug>(fern-my-leave-or-open-or-enter)
      \ fern#smart#root(
      \   "<Plug>(fern-action-leave)",
      \   "<Plug>(fern-action-open-or-enter)",
      \ )

nmap <buffer> <CR> <Plug>(fern-my-leave-or-open-or-enter)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a smart root determination feature in the tree view for more intuitive navigation.
- **Documentation**
	- Updated documentation to reflect new key mappings and functionalities for drawer actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->