### PR TITLE
doc: fix typo

### DIFF
--- a/doc/fern-develop.txt
+++ b/doc/fern-develop.txt
@@ -301,7 +301,7 @@ VARIABLE				*fern-develop-helper-variable*
 
 	"scheme"	A scheme name used to determine "provider"
 	"source"	A cancellation token source to cancel requests
-	"provider"	A provider instance for the fren tree
+	"provider"	A provider instance for the fern tree
 	"renderer"	A renderer instance to sort nodes
 	"comparator"	A comparator instance to sort nodes
 	"root"		A root node instance


### PR DESCRIPTION
SSIA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the description of the "provider" from "fren tree" to "fern tree" in the development documentation to correct a typo and clarify the terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->