### PR TITLE
fix: returns rejected promise instead throw error when call provider methods

### DIFF
--- a/autoload/fern/internal/node.vim
+++ b/autoload/fern/internal/node.vim
@@ -60,7 +60,9 @@ function! fern#internal#node#parent(node, provider, token, ...) abort
   endif
   let l:Profile = fern#profile#start('fern#internal#node#parent')
   let l:Done = fern#internal#node#process(a:node)
-  let p = a:provider.get_parent(a:node, a:token)
+  let p = s:Promise.new({ resolve ->
+        \   resolve(a:provider.get_parent(a:node, a:token))
+        \ })
         \.then({ n -> s:new(n, {
         \   '__key': [],
         \   '__owner': v:null,
@@ -91,7 +93,9 @@ function! fern#internal#node#children(node, provider, token, ...) abort
   endif
   let l:Profile = fern#profile#start('fern#internal#node#children')
   let l:Done = fern#internal#node#process(a:node)
-  let p = a:provider.get_children(a:node, a:token)
+  let p = s:Promise.new({ resolve ->
+        \   resolve(a:provider.get_children(a:node, a:token))
+        \ })
         \.then(s:AsyncLambda.map_f({ n ->
         \   s:new(n, {
         \     '__key': a:node.__key + [n.name],

--- a/autoload/fern/scheme/file/util.vim
+++ b/autoload/fern/scheme/file/util.vim
@@ -37,7 +37,8 @@ if exists('*readdir')
     let l:Profile = fern#profile#start('fern#scheme#file#util#list_entries_readdir')
     let s = s:is_windows ? '\' : '/'
     let p = a:path[-1:] ==# s ? a:path : (a:path . s)
-    return s:Promise.resolve(readdir(a:path))
+    silent! let children = readdir(a:path)
+    return s:Promise.resolve(children)
           \.then(s:AsyncLambda.map_f({ v -> p . v }))
           \.finally({ -> Profile() })
   endfunction


### PR DESCRIPTION
If the provider's method throws an error, the promise chain is broken and `Done` will not be called.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved asynchronous handling in retrieving parent and children nodes in the application, enhancing performance and responsiveness.
	- Refactored the `list_entries_readdir` function in `autoload/fern/scheme/file/util.vim` to use `Promise.new` for resolving the readdir operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->