### PR TITLE
Fix: Add viewer hooks and autocmds to hover popup for consistent highlighting

### DIFF
--- a/autoload/fern/internal/drawer/hover_popup.vim
+++ b/autoload/fern/internal/drawer/hover_popup.vim
@@ -73,11 +73,11 @@ function! s:show() abort
   function! s:apply() abort closure
     call setbufline('%', 1, line)
     call helper.fern.renderer.syntax()
-    call fern#hook#emit('viewer:highlight', helper)
-    doautocmd <nomodeline> User FernHighlight
-    call helper.fern.renderer.highlight()
     call fern#hook#emit('viewer:syntax', helper)
     doautocmd <nomodeline> User FernSyntax
+    call helper.fern.renderer.highlight()
+    call fern#hook#emit('viewer:highlight', helper)
+    doautocmd <nomodeline> User FernHighlight
     syntax clear FernRootSymbol
     syntax clear FernRootText
 


### PR DESCRIPTION
Problem:

Currently, the hover popup only calls `helper.fern.renderer.highlight()` and `helper.fern.renderer.syntax()`, which means user customizations made through `FernHighlight`/`FernSyntax` autocmds or `viewer:highlight`/`viewer:syntax` hooks are not applied to the hover popups.

As a result, fern-specific customizations made in these hooks/autocmds only affect the main window, creating visual inconsistency. This behavior makes it difficult to customize highlighting that is not defined by Fern, such as CursorLine, which is limited to fern.

See also: #283

Solution:

This PR adds `viewer:highlight`, `viewer:syntax` hooks and `FernHighlight`, `FernSyntax` autocmds to the hover popup's `s:apply()` function to ensure consistent highlighting between the main fern window and hover popups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two viewer events (FernSyntax and FernHighlight) during hover popup rendering. These events trigger User autocommands so users can hook into and customize syntax and highlight behavior for hover popups.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->