### PR TITLE
fix: apply fern.exclude filter during expand_tree

### DIFF
--- a/autoload/fern/helper/async.vim
+++ b/autoload/fern/helper/async.vim
@@ -176,6 +176,7 @@ function! s:async_expand_tree(key) abort dict
         \   fern.provider,
         \   fern.comparator,
         \   fern.source.token,
+        \   fern.exclude,
         \ )
         \})
         \.then({ ns -> self.update_nodes(ns) })

--- a/autoload/fern/internal/node.vim
+++ b/autoload/fern/internal/node.vim
@@ -142,13 +142,14 @@ function! fern#internal#node#expand(node, nodes, provider, comparator, token) ab
   return p
 endfunction
 
-function! fern#internal#node#expand_tree(node, nodes, provider, comparator, token) abort
+function! fern#internal#node#expand_tree(node, nodes, provider, comparator, token, ...) abort
+  let exclude = a:0 ? a:1 : ''
   if a:node.status is# s:STATUS_NONE
     return s:Promise.reject('cannot expand leaf node')
   elseif a:node.status is# s:STATUS_EXPANDED
     " Collapse first to avoid duplication
     return fern#internal#node#collapse(a:node, a:nodes, a:provider, a:comparator, a:token)
-      \.then({ ns -> fern#internal#node#expand_tree(a:node, ns, a:provider, a:comparator, a:token) })
+      \.then({ ns -> fern#internal#node#expand_tree(a:node, ns, a:provider, a:comparator, a:token, exclude) })
   elseif has_key(a:node.concealed, '__promise_expand')
     return a:node.concealed.__promise_expand
   elseif has_key(a:node, 'concealed.__promise_collapse')
@@ -160,6 +161,8 @@ function! fern#internal#node#expand_tree(node, nodes, provider, comparator, toke
         \.finally({ -> Profile('descendants') })
         \.then({ v -> s:sort(v, a:comparator.compare) })
         \.finally({ -> Profile('sort') })
+        \.then({ v -> s:filter_excluded(v, exclude) })
+        \.finally({ -> Profile('filter_excluded') })
         \.then(s:Lambda.map_f({ n -> n.status isnot# s:STATUS_NONE ? extend(n, {'status': s:STATUS_EXPANDED}) : n }))
         \.finally({ -> Profile('expand') })
         \.then({ v -> s:extend(a:node.__key, copy(a:nodes), v) })
@@ -273,6 +276,32 @@ endfunction
 
 function! s:sort(nodes, compare) abort
   return s:Promise.resolve(sort(a:nodes, a:compare))
+endfunction
+
+function! s:filter_excluded(nodes, exclude) abort
+  if empty(a:exclude)
+    return a:nodes
+  endif
+  let excluded_keys = []
+  let result = []
+  for node in a:nodes
+    let dominated = 0
+    for ekey in excluded_keys
+      if len(node.__key) > len(ekey) && node.__key[:len(ekey)-1] ==# ekey
+        let dominated = 1
+        break
+      endif
+    endfor
+    if dominated
+      continue
+    endif
+    if node.label =~# a:exclude
+      call add(excluded_keys, node.__key)
+      continue
+    endif
+    call add(result, node)
+  endfor
+  return result
 endfunction
 
 function! s:extend(key, nodes, new_nodes) abort


### PR DESCRIPTION
## Summary

- Add an optional `exclude` parameter to `fern#internal#node#expand_tree` so the exclude filter is applied during tree expansion
- Implement `s:filter_excluded` helper that removes nodes matching the `fern.exclude` pattern (along with their subtrees) from the expansion result
- Wire up `fern.exclude` from `s:async_expand_tree` in `fern/helper/async.vim` into the `expand_tree` call

## Why

When recursively expanding via `expand_tree`, the `fern.exclude` filter was not taken into account — excluded nodes and all their descendants were shown in the tree (Issue #543).

By incorporating the filter into the expansion step, nodes matching the exclude pattern and their entire subtrees are kept out of the tree. Ancestor-key tracking keeps the descendant-pruning cost minimal.

## Test Plan

- [ ] Set `fern.exclude` to an arbitrary pattern and confirm matching nodes are hidden during tree expansion
- [ ] Confirm descendants of excluded nodes are also hidden
- [ ] Confirm all nodes are expanded as before when `fern.exclude` is empty
- [ ] Confirm existing expand / collapse behavior has no regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Tree expansion now correctly applies exclude filters, ensuring excluded nodes and their descendants are properly hidden when expanding tree items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->