### PR TITLE
fix(hover_popup): incorrect popup position if &winborder != 'none'

### DIFF
--- a/autoload/fern/internal/drawer/hover_popup.vim
+++ b/autoload/fern/internal/drawer/hover_popup.vim
@@ -60,6 +60,7 @@ function! s:show() abort
           \ 'height': 1,
           \ 'noautocmd': v:true,
           \ 'style': 'minimal',
+          \ 'border': 'none',
           \})
   else
     " calculate position of popup


### PR DESCRIPTION
## Problem

Neovim provides options like 'rounded' for &winborder (default 'none').
When the user sets a non-'none' value, the popup position is shifted down
by 1 cell (top border width) because nvim_open_win() inherits &winborder when 'border' is omitted.

## Solution

Set 'border': 'none' explicitly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hover popup visual presentation in Neovim by removing unnecessary borders for a cleaner display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->