### PR TITLE
Add -confirm and -immediate variants for clipboard-paste

### DIFF
--- a/autoload/fern/scheme/dict/mapping/clipboard.vim
+++ b/autoload/fern/scheme/dict/mapping/clipboard.vim
@@ -6,10 +6,14 @@ let s:clipboard = {
       \}
 
 function! fern#scheme#dict#mapping#clipboard#init(disable_default_mappings) abort
-  nnoremap <buffer><silent> <Plug>(fern-action-clipboard-copy)  :<C-u>call <SID>call('clipboard_copy')<CR>
-  nnoremap <buffer><silent> <Plug>(fern-action-clipboard-move)  :<C-u>call <SID>call('clipboard_move')<CR>
-  nnoremap <buffer><silent> <Plug>(fern-action-clipboard-paste) :<C-u>call <SID>call('clipboard_paste')<CR>
-  nnoremap <buffer><silent> <Plug>(fern-action-clipboard-clear) :<C-u>call <SID>call('clipboard_clear')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-clipboard-copy)            :<C-u>call <SID>call('clipboard_copy')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-clipboard-move)            :<C-u>call <SID>call('clipboard_move')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-clipboard-paste-confirm)   :<C-u>call <SID>call('clipboard_paste', 1)<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-clipboard-paste-immediate) :<C-u>call <SID>call('clipboard_paste', 0)<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-clipboard-clear)           :<C-u>call <SID>call('clipboard_clear')<CR>
+ 
+  " Alias map
+  nmap <buffer><silent> <Plug>(fern-action-clipboard-paste) <Plug>(fern-action-clipboard-paste-confirm)
 
   if !a:disable_default_mappings
     nmap <buffer><nowait> C <Plug>(fern-action-clipboard-copy)
@@ -49,12 +53,12 @@ function! s:map_clipboard_copy(helper) abort
         \.then({ -> a:helper.sync.echo(printf('%d items are saved in clipboard to copy', len(nodes))) })
 endfunction
 
-function! s:map_clipboard_paste(helper) abort
+function! s:map_clipboard_paste(helper, confirm_move) abort
   if empty(s:clipboard)
     return s:Promise.reject('Nothing to paste')
   endif
 
-  if s:clipboard.mode ==# 'move'
+  if s:clipboard.mode ==# 'move' && a:confirm_move
     let paths = map(copy(s:clipboard.candidates), { -> v:val._path })
     let prompt = printf('The following %d nodes will be moved', len(paths))
     for path in paths[:5]

--- a/autoload/fern/scheme/file/mapping/clipboard.vim
+++ b/autoload/fern/scheme/file/mapping/clipboard.vim
@@ -6,10 +6,14 @@ let s:clipboard = {
       \}
 
 function! fern#scheme#file#mapping#clipboard#init(disable_default_mappings) abort
-  nnoremap <buffer><silent> <Plug>(fern-action-clipboard-copy)  :<C-u>call <SID>call('clipboard_copy')<CR>
-  nnoremap <buffer><silent> <Plug>(fern-action-clipboard-move)  :<C-u>call <SID>call('clipboard_move')<CR>
-  nnoremap <buffer><silent> <Plug>(fern-action-clipboard-paste) :<C-u>call <SID>call('clipboard_paste')<CR>
-  nnoremap <buffer><silent> <Plug>(fern-action-clipboard-clear) :<C-u>call <SID>call('clipboard_clear')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-clipboard-copy)            :<C-u>call <SID>call('clipboard_copy')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-clipboard-move)            :<C-u>call <SID>call('clipboard_move')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-clipboard-paste-confirm)   :<C-u>call <SID>call('clipboard_paste', 1)<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-clipboard-paste-immediate) :<C-u>call <SID>call('clipboard_paste', 0)<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-clipboard-clear)           :<C-u>call <SID>call('clipboard_clear')<CR>
+ 
+  " Alias map
+  nmap <buffer><silent> <Plug>(fern-action-clipboard-paste) <Plug>(fern-action-clipboard-paste-confirm)
 
   if !a:disable_default_mappings
     nmap <buffer><nowait> C <Plug>(fern-action-clipboard-copy)
@@ -49,12 +53,12 @@ function! s:map_clipboard_copy(helper) abort
         \.then({ -> a:helper.sync.echo(printf('%d items are saved in clipboard to copy', len(nodes))) })
 endfunction
 
-function! s:map_clipboard_paste(helper) abort
+function! s:map_clipboard_paste(helper, confirm_move) abort
   if empty(s:clipboard)
     return s:Promise.reject('Nothing to paste')
   endif
 
-  if s:clipboard.mode ==# 'move'
+  if s:clipboard.mode ==# 'move' && a:confirm_move
     let paths = map(copy(s:clipboard.candidates), { -> v:val._path })
     let prompt = printf('The following %d nodes will be moved', len(paths))
     for path in paths[:5]

--- a/doc/fern.txt
+++ b/doc/fern.txt
@@ -1300,9 +1300,13 @@ The following mappings/actions are only available on file:// scheme.
 	action.
 	Note that this action has NO-relation with the system clipboard.
 
+*<Plug>(fern-action-clipboard-paste-confirm)*
+*<Plug>(fern-action-clipboard-paste-immediate)*
 *<Plug>(fern-action-clipboard-paste)*
 	Paste copied/moved nodes on a cursor node. It does not clear the
 	internal clipboard so users can copy -> paste -> paste -> ...
+	The confirm variant prompts the user for confirmation when moving
+	files (this is default), and the immediate variant skips this prompt.
 	Note that this action has NO-relation with the system clipboard.
 
 *<Plug>(fern-action-clipboard-clear)*


### PR DESCRIPTION
This change adds the following actions:

```vim
<Plug>(fern-action-clipboard-paste-confirm)
<Plug>(fern-action-clipboard-paste-immediate)
```

Where `-confirm` prompts the user for confirmation when moving a file and `-immediate` does not. `<Plug>(fern-action-clipboard-paste)` now maps to `<Plug>(fern-action-clipboard-paste-confirm)`, which was the default behavior of the clipboard paste action before this change. As such, this is not a breaking change.

Fixes #551.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clipboard paste now offers two modes: paste with confirmation (default) and immediate paste to skip the confirmation when moving files.

* **Documentation**
  * Docs updated to describe the two paste variants and their confirmation behavior, and note the default mapping remains the confirm variant.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lambdalisue/vim-fern/pull/552?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->