### PR TITLE
fix(test): tolerate 2- or 3-entry jumplist in jumplist.vimspec

### DIFF
--- a/test/behavior/jumplist.vimspec
+++ b/test/behavior/jumplist.vimspec
@@ -42,11 +42,23 @@ Describe jumplist
     let output = split(execute('jumps'), '\n')
     " NOTE:
     " It seems '-wait' affects 'jumps' somehow
-    Assert Match(output[1], '^\s\+3\s\+1\s\+\d\+ alpha$', output)
-    Assert Match(output[2], '^\s\+2\s\+1\s\+\d\+ fern://.*/file:///.*$', output)
-    Assert Match(output[3], '^\s\+1\s\+4\s\+\d\+ fern://.*/file:///.*$', output)
-    Assert Match(output[4], '^>$', output)
-    Assert Equals(len(output), 5)
+    "
+    " On Vim (and Neovim up to v0.4.4) leaving the fern buffer via 'edit'
+    " records an extra jump, so the jumplist holds two fern:// entries.
+    " Recent Neovim no longer records that jump, leaving a single fern://
+    " entry. Either way the jumplist must be updated (alpha is kept as the
+    " most distant jump), unlike the keepjumps_on_edit is 1 case below.
+    if len(output) == 5
+      Assert Match(output[1], '^\s\+3\s\+1\s\+\d\+ alpha$', output)
+      Assert Match(output[2], '^\s\+2\s\+1\s\+\d\+ fern://.*/file:///.*$', output)
+      Assert Match(output[3], '^\s\+1\s\+4\s\+\d\+ fern://.*/file:///.*$', output)
+      Assert Match(output[4], '^>$', output)
+    else
+      Assert Match(output[1], '^\s\+2\s\+1\s\+\d\+ alpha$', output)
+      Assert Match(output[2], '^\s\+1\s\+1\s\+\d\+ fern://.*/file:///.*$', output)
+      Assert Match(output[3], '^>$', output)
+      Assert Equals(len(output), 4)
+    endif
   End
 
   It Fern keeps jumps after 'open:edit' action in split windows style if g:fern#keepjumps_on_edit is 1


### PR DESCRIPTION
Fixes #549

## Summary

- The jumplist test was written to expect exactly 5 lines (3 numbered jump entries + `>` + header), which assumed that leaving the fern buffer via `edit` always records two `fern://` entries.
- Recent stable Neovim no longer records that extra jump, producing only 4 lines (2 numbered entries + `>` + header), causing the assertion to fail on CI.
- The test now branches on the actual length of the jumplist output and validates whichever shape is present, while still asserting the semantically important invariant: `alpha` is retained as the most distant jump.

## Why

The behavioral difference is a Neovim internal change in how `edit` interacts with the jumplist. Both the old (5-entry) and new (4-entry) shapes are correct from fern's perspective — what matters is that the jumplist *is* updated and that `alpha` survives as the oldest entry. Hard-coding the 5-entry shape made CI brittle against Neovim upgrades.

## Test Plan

- [ ] Confirm CI passes on the latest stable Neovim
- [ ] Confirm CI still passes on older Neovim / Vim where the 5-entry shape is produced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated jumplist behavior validation tests to support multiple Vim/Neovim versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->