### PR TITLE
Fix incorrect window labels when 10 or more windows are open

### DIFF
--- a/autoload/vital/_fern/App/WindowSelector.vim
+++ b/autoload/vital/_fern/App/WindowSelector.vim
@@ -58,7 +58,10 @@ function! s:select(winnrs, ...) abort
             \   : options.statusline_hl,
             \ options.indicator_hl,
             \])
-      call map(keys(store), { k, v -> setwinvar(v, target, S(v, chars[k])) })
+      for i in range(length)
+        let winnr = a:winnrs[i]
+        call setwinvar(winnr, target, S(winnr, chars[i]))
+      endfor
       redrawstatus
     endif
     call s:_cnoremap_all(chars)
@@ -77,7 +80,9 @@ function! s:select(winnrs, ...) abort
     if options.use_popup
       call s:_clear_popups()
     else
-      call map(keys(store), { _, v -> setwinvar(v, target, store[v]) })
+      for winnr in a:winnrs
+        call setwinvar(winnr, target, store[winnr])
+      endfor
       redrawstatus
     endif
   endtry


### PR DESCRIPTION
## Summary

Fixes incorrect window labels when 10 or more windows are open.

## Description

When selecting a file through fern, window statuslines are labeled in alphabetical order (a, b, c ... i). When there are 10 or more windows, the labels become incorrect (b, c, d ... j, a).

## Cause

The previous implementation relied on iterating over keys(store), which could produce an ordering different from a:winnrs. As a result, labels could be assigned to the wrong windows.

## Solution

Iterate over `a:winnrs` directly when assigning and restoring window labels, preserving the intended correspondence between window numbers and label characters.

## Testing

Reproduced the issue with 10 or more windows and verified that each window now receives the correct label.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved window selection indicators so labels consistently appear in the correct windows.
  - Ensured original window status and toolbar displays are reliably restored after selection, including when popup windows are unavailable.
  - Improved consistency of the window selector across different window layouts and configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->